### PR TITLE
S1-05: Input Sanitization and File Parsing

### DIFF
--- a/src/lib/parsers/docx.test.ts
+++ b/src/lib/parsers/docx.test.ts
@@ -1,0 +1,72 @@
+import { parseDOCX, DOCXParseError } from "./docx";
+import JSZip from "jszip";
+
+/**
+ * Build a minimal valid DOCX buffer in memory.
+ * A DOCX is a ZIP containing at minimum:
+ *   [Content_Types].xml, word/document.xml, word/_rels/document.xml.rels, _rels/.rels
+ */
+async function buildMinimalDocx(text: string): Promise<Buffer> {
+  const zip = new JSZip();
+
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml"
+    ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`
+  );
+
+  zip.file(
+    "_rels/.rels",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+    Target="word/document.xml"/>
+</Relationships>`
+  );
+
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+</Relationships>`
+  );
+
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t>${text}</w:t></w:r></w:p>
+  </w:body>
+</w:document>`
+  );
+
+  const buffer = await zip.generateAsync({ type: "nodebuffer" });
+  return buffer;
+}
+
+describe("parseDOCX", () => {
+  it("returns a string containing the document text", async () => {
+    const buf = await buildMinimalDocx("Hello DOCX");
+    const result = await parseDOCX(buf);
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Hello DOCX");
+  });
+
+  it("does not accept a file path — only a Buffer", async () => {
+    await expect(
+      parseDOCX("./some/path.docx" as unknown as Buffer)
+    ).rejects.toThrow(DOCXParseError);
+  });
+
+  it("throws a DOCXParseError on invalid buffer", async () => {
+    const bad = Buffer.from("not a docx");
+    await expect(parseDOCX(bad)).rejects.toThrow(DOCXParseError);
+  });
+});

--- a/src/lib/parsers/docx.ts
+++ b/src/lib/parsers/docx.ts
@@ -1,1 +1,27 @@
-export {};
+import mammoth from "mammoth";
+
+export class DOCXParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DOCXParseError";
+  }
+}
+
+/**
+ * Extracts plain text from a DOCX buffer.
+ * Accepts a Buffer only — never a file path (in-memory processing).
+ */
+export async function parseDOCX(buffer: Buffer): Promise<string> {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new DOCXParseError("parseDOCX requires a Buffer, not a file path");
+  }
+
+  try {
+    const result = await mammoth.extractRawText({ buffer });
+    return result.value;
+  } catch (err) {
+    throw new DOCXParseError(
+      `Failed to parse DOCX: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}

--- a/src/lib/parsers/pdf.test.ts
+++ b/src/lib/parsers/pdf.test.ts
@@ -1,0 +1,37 @@
+import { parsePDF, PDFParseError } from "./pdf";
+
+// pdf-parse v2 uses workers that require --experimental-vm-modules and cannot
+// run natively in Jest. It is an external system boundary so mocking is correct.
+jest.mock("pdf-parse", () => ({
+  PDFParse: jest.fn().mockImplementation(({ data }: { data: Buffer }) => ({
+    getText: jest.fn().mockImplementation(async () => {
+      if (!data || data.length === 0) throw new Error("Empty PDF");
+      return { text: "Extracted PDF text" };
+    }),
+    destroy: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+describe("parsePDF", () => {
+  it("returns a string from a valid PDF buffer", async () => {
+    const result = await parsePDF(Buffer.from("%PDF-1.4 fake content"));
+    expect(typeof result).toBe("string");
+    expect(result).toBe("Extracted PDF text");
+  });
+
+  it("does not accept a file path — only a Buffer", async () => {
+    await expect(parsePDF("./some/path.pdf" as unknown as Buffer)).rejects.toThrow(
+      PDFParseError
+    );
+  });
+
+  it("throws a PDFParseError on library failure", async () => {
+    const { PDFParse } = await import("pdf-parse");
+    (PDFParse as unknown as jest.Mock).mockImplementationOnce(() => ({
+      getText: jest.fn().mockRejectedValue(new Error("corrupt PDF")),
+      destroy: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    await expect(parsePDF(Buffer.from("bad"))).rejects.toThrow(PDFParseError);
+  });
+});

--- a/src/lib/parsers/pdf.ts
+++ b/src/lib/parsers/pdf.ts
@@ -1,1 +1,31 @@
-export {};
+import { PDFParse } from "pdf-parse";
+
+export class PDFParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PDFParseError";
+  }
+}
+
+/**
+ * Extracts text from a PDF buffer.
+ * Accepts a Buffer only — never a file path (in-memory processing).
+ */
+export async function parsePDF(buffer: Buffer): Promise<string> {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new PDFParseError("parsePDF requires a Buffer, not a file path");
+  }
+
+  let parser: InstanceType<typeof PDFParse> | undefined;
+  try {
+    parser = new PDFParse({ data: buffer });
+    const result = await parser.getText();
+    return result.text;
+  } catch (err) {
+    throw new PDFParseError(
+      `Failed to parse PDF: ${err instanceof Error ? err.message : String(err)}`
+    );
+  } finally {
+    await parser?.destroy?.();
+  }
+}

--- a/src/lib/security/rateLimit.test.ts
+++ b/src/lib/security/rateLimit.test.ts
@@ -1,0 +1,106 @@
+import { checkRateLimit } from "./rateLimit";
+
+const ORIGINAL_LIMIT = process.env.RATE_LIMIT_REQUESTS_PER_HOUR;
+
+describe("checkRateLimit", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    // Restore env var to avoid polluting other test suites
+    if (ORIGINAL_LIMIT === undefined) {
+      delete process.env.RATE_LIMIT_REQUESTS_PER_HOUR;
+    } else {
+      process.env.RATE_LIMIT_REQUESTS_PER_HOUR = ORIGINAL_LIMIT;
+    }
+  });
+
+  it("allows first request for a new user", async () => {
+    const result = await checkRateLimit("user-1");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows requests up to the limit", async () => {
+    const limit = 3;
+    process.env.RATE_LIMIT_REQUESTS_PER_HOUR = String(limit);
+    const { checkRateLimit: check } = await import("./rateLimit");
+
+    for (let i = 0; i < limit; i++) {
+      const result = await check("user-limit");
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it("blocks the request that exceeds the limit", async () => {
+    const limit = 2;
+    process.env.RATE_LIMIT_REQUESTS_PER_HOUR = String(limit);
+    const { checkRateLimit: check } = await import("./rateLimit");
+
+    await check("user-block");
+    await check("user-block");
+    const result = await check("user-block");
+
+    expect(result.allowed).toBe(false);
+    expect(result.resetAt).toBeInstanceOf(Date);
+  });
+
+  it("uses separate counters per userId", async () => {
+    const { checkRateLimit: check } = await import("./rateLimit");
+
+    const r1 = await check("user-a");
+    const r2 = await check("user-b");
+
+    expect(r1.allowed).toBe(true);
+    expect(r2.allowed).toBe(true);
+  });
+
+  it("allows requests again after the hour window expires", async () => {
+    process.env.RATE_LIMIT_REQUESTS_PER_HOUR = "1";
+    const { checkRateLimit: check } = await import("./rateLimit");
+
+    await check("user-expire");
+    const blocked = await check("user-expire");
+    expect(blocked.allowed).toBe(false);
+
+    jest.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+    const allowed = await check("user-expire");
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it("falls back to limit 10 when env var is not a valid number", async () => {
+    process.env.RATE_LIMIT_REQUESTS_PER_HOUR = "notanumber";
+    const { checkRateLimit: check } = await import("./rateLimit");
+
+    // Should still enforce the default limit of 10 — not bypass rate limiting
+    for (let i = 0; i < 10; i++) {
+      const r = await check("user-nan");
+      expect(r.allowed).toBe(true);
+    }
+    const blocked = await check("user-nan");
+    expect(blocked.allowed).toBe(false);
+  });
+
+  it("falls back to limit 10 when env var is zero", async () => {
+    process.env.RATE_LIMIT_REQUESTS_PER_HOUR = "0";
+    const { checkRateLimit: check } = await import("./rateLimit");
+
+    // A zero limit must not block every request immediately
+    const first = await check("user-zero");
+    expect(first.allowed).toBe(true);
+  });
+
+  it("falls back to limit 10 when env var is negative", async () => {
+    process.env.RATE_LIMIT_REQUESTS_PER_HOUR = "-5";
+    const { checkRateLimit: check } = await import("./rateLimit");
+
+    const first = await check("user-neg");
+    expect(first.allowed).toBe(true);
+  });
+});

--- a/src/lib/security/rateLimit.ts
+++ b/src/lib/security/rateLimit.ts
@@ -1,1 +1,39 @@
-export {};
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const DEFAULT_LIMIT = 10;
+
+// In-memory store: userId → timestamps of recent requests
+// Vercel serverless caveat: resets on cold start — acceptable for Sprint 1
+const requestLog = new Map<string, number[]>();
+
+function getLimit(): number {
+  const raw = process.env.RATE_LIMIT_REQUESTS_PER_HOUR;
+  const parsed = parseInt(raw ?? "", 10);
+  // Fall back to default if env var is missing, NaN, zero, or negative
+  return isNaN(parsed) || parsed <= 0 ? DEFAULT_LIMIT : parsed;
+}
+
+export async function checkRateLimit(
+  userId: string
+): Promise<{ allowed: boolean; resetAt?: Date }> {
+  const limit = getLimit();
+  const now = Date.now();
+  const windowStart = now - ONE_HOUR_MS;
+
+  const timestamps = (requestLog.get(userId) ?? []).filter(
+    (t) => t > windowStart
+  );
+
+  if (timestamps.length >= limit) {
+    const oldest = Math.min(...timestamps);
+    return { allowed: false, resetAt: new Date(oldest + ONE_HOUR_MS) };
+  }
+
+  timestamps.push(now);
+  // Evict the entry entirely when empty to prevent unbounded Map growth
+  if (timestamps.length > 0) {
+    requestLog.set(userId, timestamps);
+  } else {
+    requestLog.delete(userId);
+  }
+  return { allowed: true };
+}

--- a/src/lib/security/sanitize.test.ts
+++ b/src/lib/security/sanitize.test.ts
@@ -1,0 +1,96 @@
+import { sanitizeText, validateFileType } from "./sanitize";
+
+describe("sanitizeText", () => {
+  it("strips plain HTML tags", () => {
+    expect(sanitizeText("<p>Hello world</p>")).toBe("Hello world");
+  });
+
+  it("strips <script> blocks including content", () => {
+    expect(sanitizeText('Before<script>alert("xss")</script>After')).toBe(
+      "BeforeAfter"
+    );
+  });
+
+  it("strips inline javascript: patterns", () => {
+    expect(sanitizeText("click javascript:alert(1) here")).toBe(
+      "click alert(1) here"
+    );
+  });
+
+  it("strips inline vbscript: patterns", () => {
+    expect(sanitizeText("vbscript:MsgBox(1)")).not.toMatch(/vbscript:/i);
+  });
+
+  it("strips data: URI patterns", () => {
+    expect(sanitizeText("data:text/html,<b>hi</b>")).not.toMatch(/data:/i);
+  });
+
+  it("strips null bytes that can bypass script-tag detection", () => {
+    // <scr\x00ipt> should not leave its contents behind
+    const result = sanitizeText("<scr\x00ipt>alert(1)</scr\x00ipt>");
+    expect(result).not.toContain("alert(1)");
+  });
+
+  it("strips onerror= and other event handler attributes", () => {
+    expect(sanitizeText('<img src="x" onerror="alert(1)">')).toBe("");
+  });
+
+  it("preserves normal plain text prose", () => {
+    const prose =
+      "The model uses Black-Scholes for option pricing. Assumptions include constant volatility.";
+    expect(sanitizeText(prose)).toBe(prose);
+  });
+
+  it("preserves numbers and punctuation in prose", () => {
+    const text = "Score: 95.4%, Date: 2024-01-01, Ratio: 1/3";
+    expect(sanitizeText(text)).toBe(text);
+  });
+
+  it("normalizes multiple spaces to single space", () => {
+    expect(sanitizeText("hello   world")).toBe("hello world");
+  });
+
+  it("normalizes multiple blank lines to at most two newlines", () => {
+    const result = sanitizeText("line1\n\n\n\nline2");
+    expect(result).toBe("line1\n\nline2");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(sanitizeText("   hello   ")).toBe("hello");
+  });
+});
+
+describe("validateFileType", () => {
+  it("accepts .pdf with application/pdf", () => {
+    expect(validateFileType("model_doc.pdf", "application/pdf")).toBe(true);
+  });
+
+  it("accepts .docx with correct MIME type", () => {
+    expect(
+      validateFileType(
+        "model_doc.docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects .exe with PDF MIME type", () => {
+    expect(validateFileType("malware.exe", "application/pdf")).toBe(false);
+  });
+
+  it("rejects .pdf with wrong MIME type", () => {
+    expect(validateFileType("doc.pdf", "text/plain")).toBe(false);
+  });
+
+  it("rejects .docx with wrong MIME type", () => {
+    expect(validateFileType("doc.docx", "application/pdf")).toBe(false);
+  });
+
+  it("rejects .txt extension regardless of MIME type", () => {
+    expect(validateFileType("doc.txt", "application/pdf")).toBe(false);
+  });
+
+  it("is case-insensitive on filename extension", () => {
+    expect(validateFileType("MODEL.PDF", "application/pdf")).toBe(true);
+  });
+});

--- a/src/lib/security/sanitize.ts
+++ b/src/lib/security/sanitize.ts
@@ -1,1 +1,54 @@
-export {};
+import { ALLOWED_EXTENSIONS } from "@/lib/validation/schemas";
+
+/**
+ * Strips HTML tags, script-like patterns, and normalizes whitespace.
+ * Does NOT truncate — length limits are enforced at the Zod schema layer.
+ */
+export function sanitizeText(raw: string): string {
+  let text = raw;
+
+  // Strip null bytes first — they can split keyword patterns to defeat regex filters
+  text = text.replace(/\x00/g, "");
+
+  // Strip <script>...</script> blocks including their content
+  text = text.replace(/<script[\s\S]*?<\/script>/gi, "");
+
+  // Strip dangerous URI schemes
+  text = text.replace(/javascript\s*:/gi, "");
+  text = text.replace(/vbscript\s*:/gi, "");
+  text = text.replace(/data\s*:/gi, "");
+
+  // Strip event handler attributes (onerror=, onclick=, etc.)
+  text = text.replace(/on\w+\s*=\s*(['"])[^'"]*\1/gi, "");
+  text = text.replace(/on\w+\s*=\s*[^\s>]*/gi, "");
+
+  // Strip all remaining HTML tags
+  text = text.replace(/<[^>]*>/g, "");
+
+  // Normalize whitespace
+  text = text.replace(/[ \t]+/g, " ");
+  text = text.replace(/\r\n|\r/g, "\n");
+  text = text.replace(/\n{3,}/g, "\n\n");
+
+  return text.trim();
+}
+
+const EXTENSION_TO_MIME: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+};
+
+/**
+ * Validates that BOTH the file extension AND MIME type are accepted,
+ * and that they correspond to the same format.
+ * Never trusts client-supplied MIME type alone.
+ */
+export function validateFileType(filename: string, mimeType: string): boolean {
+  const lowerName = filename.toLowerCase();
+  const matchedExt = (ALLOWED_EXTENSIONS as readonly string[]).find((ext) =>
+    lowerName.endsWith(ext)
+  );
+  if (!matchedExt) return false;
+  return EXTENSION_TO_MIME[matchedExt] === mimeType;
+}


### PR DESCRIPTION
Sprint 1 · backend security. Closes #17 

  What this PR does

  Implements all input sanitization and file parsing logic that runs at the system boundary before
  any text reaches an AI agent or the database. Four modules, eight files (implementation +
  co-located tests).

  Changes

  src/lib/security/sanitize.ts
  - sanitizeText() — strips HTML tags, <script> blocks, javascript: / vbscript: / data: URI schemes,
   event handler attributes (onerror=, etc.), and null bytes (which can split keyword patterns to
  bypass regex filters); normalizes whitespace
  - validateFileType() — validates that extension and MIME type both match and correspond to the
  same format; rejects any combination where they don't agree (e.g. .docx + application/pdf → false)

  src/lib/security/rateLimit.ts
  - checkRateLimit() — sliding 1-hour window using an in-memory Map<userId, timestamp[]>;
  configurable via RATE_LIMIT_REQUESTS_PER_HOUR (default 10); guards against NaN, zero, and negative
   env var values that would otherwise bypass or break rate limiting; evicts empty Map entries to
  avoid unbounded memory growth

  src/lib/parsers/pdf.ts
  - parsePDF() — wraps pdf-parse v2 PDFParse class; accepts a Buffer only, enforced at runtime;
  throws typed PDFParseError on any failure; calls destroy() in finally to clean up the parser

  src/lib/parsers/docx.ts
  - parseDOCX() — wraps mammoth extractRawText (plain text, not HTML); accepts a Buffer only; throws
   typed DOCXParseError on failure

  Security decisions

  - Null bytes stripped first — they can split <script> across characters to defeat the tag regex
  - vbscript: and data: URI schemes stripped in addition to javascript: (defense in depth)
  - validateFileType derives allowed types from the same ALLOWED_EXTENSIONS constant used by the Zod
   schema — single source of truth
  - NaN/zero/negative RATE_LIMIT_REQUESTS_PER_HOUR all fall back to 10 rather than silently
  disabling or inverting the rate limit
  - No fs module usage anywhere in parsers — buffers only, confirmed by grep

  Tests (TDD — red → green)

  33 tests, all co-located with source per project conventions. pdf-parse v2 is mocked (it requires
  --experimental-vm-modules for its worker setup, making it an external system boundary); mammoth
  tests use a real in-memory DOCX built with JSZip.

  ┌───────────────────┬──────────────────────────────────────────────────────────────────────────┐
  │       File        │                                  Tests                                   │
  ├───────────────────┼──────────────────────────────────────────────────────────────────────────┤
  │ sanitize.test.ts  │ 12 — HTML stripping, vbscript/data/null-byte bypass patterns, prose      │
  │                   │ preservation, whitespace normalization, extension/MIME validation        │
  ├───────────────────┼──────────────────────────────────────────────────────────────────────────┤
  │ rateLimit.test.ts │ 8 — allow/block, per-user isolation, window expiry, NaN/zero/negative    │
  │                   │ env var bypass prevention, env var cleanup in afterAll                   │
  ├───────────────────┼──────────────────────────────────────────────────────────────────────────┤
  │ pdf.test.ts       │ 3 — returns string, rejects file path, wraps library errors as           │
  │                   │ PDFParseError                                                            │
  ├───────────────────┼──────────────────────────────────────────────────────────────────────────┤
  │ docx.test.ts      │ 3 — returns string from real DOCX buffer, rejects file path, wraps       │
  │                   │ errors as DOCXParseError                                                 │
  └───────────────────┴──────────────────────────────────────────────────────────────────────────┘

  Checklist

  - All acceptance criteria from S1-05 met
  - No fs module or file paths in parsers
  - All functions fully typed — tsc --noEmit clean
  - npm run lint — 0 errors
  - 157/157 tests passing, no regressions