### PR TITLE
Feat/s2 06 submissions

### DIFF
--- a/docs/prova-github-issues.md
+++ b/docs/prova-github-issues.md
@@ -21,7 +21,7 @@
 | S2-03 | Update POST /api/compliance — Full 3-Agent + Judge + Scoring Flow | 2 | ✅ Done |
 | S2-04 | Dashboard Page — Overview, Model Inventory, Score Chart, Activity Feed | 2 | ✅ Done |
 | S2-05 | New Compliance Check Page (`/check`) | 2 | ✅ Done |
-| S2-06 | Submission History and Single Submission View | 2 | 🔲 Pending |
+| S2-06 | Submission History and Single Submission View | 2 | ✅ Done |
 | S2-07 | PDF Report Generation (`POST /api/report`) | 2 | 🔲 Pending |
 | S2-08 | Settings Page (Dashboard Preferences) | 2 | ✅ Done |
 | S3-01 | GitHub Actions CI/CD Pipeline | 3 | 🔲 Pending |
@@ -310,7 +310,7 @@ Full results view:
 
 ---
 
-## Issue S2-06 🔲 PENDING: Submission History and Single Submission View
+## Issue S2-06 ✅ DONE: Submission History and Single Submission View
 
 **Labels:** `sprint-2` `frontend` `backend`
 **Milestone:** Sprint 2 (Mar 30–Apr 9)

--- a/src/app/(dashboard)/submissions/[id]/page.tsx
+++ b/src/app/(dashboard)/submissions/[id]/page.tsx
@@ -1,3 +1,566 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import type { SubmissionDetail, Gap } from "@/lib/validation/schemas";
+import Badge from "@/components/ui/Badge";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import Skeleton from "@/components/ui/Skeleton";
+import Toast from "@/components/ui/Toast";
+import { getScoreColor } from "@/components/dashboard/utils";
+import type { Status } from "@/components/dashboard/utils";
+import PillarScoreCard from "@/components/compliance/PillarScoreCard";
+import GapAnalysisTable from "@/components/compliance/GapAnalysisTable";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function countGapsBySeverity(
+  gaps: Gap[],
+  prefix: "CS" | "OA" | "OM"
+): { critical: number; major: number; minor: number } {
+  const pillarGaps = gaps.filter((g) => g.element_code.startsWith(prefix));
+  return {
+    critical: pillarGaps.filter((g) => g.severity === "Critical").length,
+    major: pillarGaps.filter((g) => g.severity === "Major").length,
+    minor: pillarGaps.filter((g) => g.severity === "Minor").length,
+  };
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function ConfidenceBadge({ label }: { label: string }) {
+  const colors: Record<string, string> = {
+    High: "var(--color-compliant)",
+    Medium: "var(--color-warning)",
+    Low: "var(--color-critical)",
+  };
+  const color = colors[label] ?? "var(--color-text-secondary)";
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        padding: "3px 10px",
+        borderRadius: "100px",
+        background: `color-mix(in srgb, ${color} 12%, transparent)`,
+        border: `1px solid color-mix(in srgb, ${color} 25%, transparent)`,
+        fontFamily: "var(--font-geist)",
+        fontSize: "11px",
+        fontWeight: 500,
+        color,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label} Confidence
+    </span>
+  );
+}
+
+// ─── Loading skeleton ────────────────────────────────────────────────────────
+
+function DetailLoadingSkeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+      {/* Main score card skeleton */}
+      <div
+        style={{
+          background: "var(--color-bg-secondary)",
+          border: "1px solid var(--color-border)",
+          borderRadius: "2px",
+          padding: "24px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            marginBottom: "16px",
+          }}
+        >
+          <Skeleton width={180} height={14} />
+          <div style={{ display: "flex", gap: "8px" }}>
+            <Skeleton width={100} height={24} borderRadius={100} />
+            <Skeleton width={90} height={24} borderRadius={100} />
+          </div>
+        </div>
+        <Skeleton width={120} height={72} style={{ marginBottom: "16px" }} />
+        <Skeleton
+          height={1}
+          style={{ width: "100%", marginBottom: "16px" }}
+        />
+        <div style={{ display: "flex", gap: "20px" }}>
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i}>
+              <Skeleton
+                width={40}
+                height={18}
+                style={{ marginBottom: "4px" }}
+              />
+              <Skeleton width={50} height={10} />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 3 pillar card skeletons */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            style={{
+              background: "var(--color-bg-secondary)",
+              border: "1px solid var(--color-border)",
+              borderRadius: "2px",
+              padding: "20px",
+            }}
+          >
+            <Skeleton
+              width={140}
+              height={10}
+              style={{ marginBottom: "12px" }}
+            />
+            <Skeleton
+              width={60}
+              height={36}
+              style={{ marginBottom: "16px" }}
+            />
+            <Skeleton
+              height={1}
+              style={{ width: "100%", marginBottom: "12px" }}
+            />
+            <div style={{ display: "flex", gap: "12px" }}>
+              {[0, 1, 2].map((j) => (
+                <Skeleton key={j} width={40} height={16} style={{ flex: 1 }} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Gap table skeleton */}
+      <div>
+        <Skeleton width={120} height={18} style={{ marginBottom: "12px" }} />
+        <div
+          style={{
+            background: "var(--color-bg-secondary)",
+            border: "1px solid var(--color-border)",
+            overflow: "hidden",
+          }}
+        >
+          <Skeleton height={36} style={{ width: "100%" }} />
+          {[0, 1, 2, 3, 4].map((i) => (
+            <Skeleton
+              key={i}
+              height={48}
+              style={{ width: "100%", opacity: 1 - i * 0.15 }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main page component ─────────────────────────────────────────────────────
+
 export default function SubmissionDetailPage() {
-  return null;
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [submission, setSubmission] = useState<SubmissionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "error";
+  } | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+
+    async function fetchDetail() {
+      setLoading(true);
+      setNotFound(false);
+      try {
+        const res = await fetch(`/api/submissions/${id}`);
+        if (res.status === 404) {
+          setNotFound(true);
+          setLoading(false);
+          return;
+        }
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as {
+            message?: string;
+          } | null;
+          setToast({
+            message: body?.message ?? "Failed to load submission.",
+            type: "error",
+          });
+          setLoading(false);
+          return;
+        }
+        const data = (await res.json()) as SubmissionDetail;
+        setSubmission(data);
+      } catch {
+        setToast({
+          message: "Network error. Please check your connection.",
+          type: "error",
+        });
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchDetail();
+  }, [id]);
+
+  const gapStats = useMemo(() => {
+    if (!submission) return null;
+    const gaps = submission.gap_analysis;
+    return {
+      total: gaps.length,
+      critical: gaps.filter((g) => g.severity === "Critical").length,
+      major: gaps.filter((g) => g.severity === "Major").length,
+      minor: gaps.filter((g) => g.severity === "Minor").length,
+      cs: countGapsBySeverity(gaps, "CS"),
+      oa: countGapsBySeverity(gaps, "OA"),
+      om: countGapsBySeverity(gaps, "OM"),
+    };
+  }, [submission]);
+
+  return (
+    <main
+      style={{
+        background: "var(--color-bg-primary)",
+        minHeight: "100vh",
+        padding: "32px 20px",
+      }}
+    >
+      <div style={{ maxWidth: 900, margin: "0 auto" }}>
+        {/* Back link */}
+        <Link
+          href="/submissions"
+          style={{
+            fontFamily: "var(--font-geist)",
+            fontSize: "13px",
+            color: "var(--color-accent)",
+            textDecoration: "none",
+            display: "inline-block",
+            marginBottom: "24px",
+          }}
+        >
+          &larr; Back to History
+        </Link>
+
+        {/* Loading */}
+        {loading && <DetailLoadingSkeleton />}
+
+        {/* Not found */}
+        {!loading && notFound && (
+          <Card animate>
+            <div style={{ textAlign: "center", padding: "48px 0" }}>
+              <div
+                style={{
+                  fontFamily: "var(--font-geist)",
+                  fontSize: "14px",
+                  color: "var(--color-text-secondary)",
+                  marginBottom: "6px",
+                }}
+              >
+                Submission not found
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-geist)",
+                  fontSize: "12px",
+                  color: "var(--color-text-secondary)",
+                  marginBottom: "16px",
+                }}
+              >
+                This submission may have been deleted.
+              </div>
+              <Link
+                href="/submissions"
+                style={{
+                  fontFamily: "var(--font-geist)",
+                  fontSize: "12px",
+                  fontWeight: 500,
+                  color: "var(--color-accent)",
+                  textDecoration: "none",
+                }}
+              >
+                Back to Submission History &rarr;
+              </Link>
+            </div>
+          </Card>
+        )}
+
+        {/* Detail content */}
+        {!loading && submission && gapStats && (
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "24px" }}
+          >
+            {/* Low confidence warning */}
+            {submission.assessment_confidence_label === "Low" && (
+              <motion.div
+                initial={{ opacity: 0, y: -8 }}
+                animate={{ opacity: 1, y: 0 }}
+                style={{
+                  background:
+                    "color-mix(in srgb, var(--color-warning) 10%, var(--color-bg-secondary))",
+                  border:
+                    "1px solid color-mix(in srgb, var(--color-warning) 30%, transparent)",
+                  borderRadius: "2px",
+                  padding: "14px 20px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "10px",
+                }}
+              >
+                <span
+                  style={{
+                    display: "block",
+                    width: "8px",
+                    height: "8px",
+                    borderRadius: "50%",
+                    background: "var(--color-warning)",
+                    flexShrink: 0,
+                  }}
+                />
+                <span
+                  style={{
+                    fontFamily: "var(--font-geist)",
+                    fontSize: "13px",
+                    color: "var(--color-warning)",
+                    lineHeight: 1.4,
+                  }}
+                >
+                  Low confidence assessment — results may be less reliable.
+                  Consider resubmitting with more detailed documentation.
+                </span>
+              </motion.div>
+            )}
+
+            {/* Main score card */}
+            <Card animate delay={0}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  flexWrap: "wrap",
+                  gap: "16px",
+                  marginBottom: "16px",
+                }}
+              >
+                <div>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-geist)",
+                      fontSize: "14px",
+                      color: "var(--color-text-primary)",
+                      marginBottom: "4px",
+                    }}
+                  >
+                    {submission.model_name}{" "}
+                    <span
+                      style={{
+                        fontFamily: "var(--font-ibm-plex-mono)",
+                        fontSize: "11px",
+                        color: "var(--color-text-secondary)",
+                        background: "var(--color-bg-tertiary)",
+                        padding: "2px 6px",
+                        borderRadius: "2px",
+                        marginLeft: "6px",
+                      }}
+                    >
+                      v{submission.version_number}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-geist)",
+                      fontSize: "10px",
+                      letterSpacing: "0.14em",
+                      textTransform: "uppercase",
+                      color: "var(--color-text-secondary)",
+                    }}
+                  >
+                    Compliance Score &middot;{" "}
+                    {formatDate(submission.created_at)}
+                  </div>
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                  }}
+                >
+                  <ConfidenceBadge
+                    label={submission.assessment_confidence_label}
+                  />
+                  <Badge status={submission.status as Status} />
+                </div>
+              </div>
+
+              {/* Large score */}
+              <div
+                style={{
+                  fontFamily: "var(--font-ibm-plex-mono)",
+                  fontSize: "72px",
+                  fontWeight: 600,
+                  lineHeight: 1,
+                  color: getScoreColor(submission.final_score),
+                  marginBottom: "16px",
+                }}
+              >
+                {Math.round(submission.final_score)}
+              </div>
+
+              {/* Gap summary row */}
+              <div
+                style={{
+                  display: "flex",
+                  gap: "20px",
+                  borderTop: "1px solid var(--color-border)",
+                  paddingTop: "16px",
+                }}
+              >
+                {[
+                  {
+                    label: "Total Gaps",
+                    value: gapStats.total,
+                    color: "var(--color-text-primary)",
+                  },
+                  {
+                    label: "Critical",
+                    value: gapStats.critical,
+                    color:
+                      gapStats.critical > 0
+                        ? "var(--color-critical)"
+                        : "var(--color-text-secondary)",
+                  },
+                  {
+                    label: "Major",
+                    value: gapStats.major,
+                    color:
+                      gapStats.major > 0
+                        ? "var(--color-warning)"
+                        : "var(--color-text-secondary)",
+                  },
+                  {
+                    label: "Minor",
+                    value: gapStats.minor,
+                    color: "var(--color-text-secondary)",
+                  },
+                ].map((item) => (
+                  <div key={item.label}>
+                    <div
+                      style={{
+                        fontFamily: "var(--font-ibm-plex-mono)",
+                        fontSize: "18px",
+                        fontWeight: 600,
+                        color: item.color,
+                        marginBottom: "2px",
+                      }}
+                    >
+                      {item.value}
+                    </div>
+                    <div
+                      style={{
+                        fontFamily: "var(--font-geist)",
+                        fontSize: "10px",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.08em",
+                        color: "var(--color-text-secondary)",
+                      }}
+                    >
+                      {item.label}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+
+            {/* Pillar score cards */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <PillarScoreCard
+                pillarName="Conceptual Soundness"
+                weight="40%"
+                score={submission.conceptual_score}
+                gapCounts={gapStats.cs}
+                delay={0.08}
+              />
+              <PillarScoreCard
+                pillarName="Outcomes Analysis"
+                weight="35%"
+                score={submission.outcomes_score}
+                gapCounts={gapStats.oa}
+                delay={0.16}
+              />
+              <PillarScoreCard
+                pillarName="Ongoing Monitoring"
+                weight="25%"
+                score={submission.monitoring_score}
+                gapCounts={gapStats.om}
+                delay={0.24}
+              />
+            </div>
+
+            {/* Gap analysis table */}
+            <div>
+              <div
+                style={{
+                  fontFamily: "var(--font-playfair)",
+                  fontSize: "18px",
+                  fontWeight: 600,
+                  color: "var(--color-text-primary)",
+                  marginBottom: "12px",
+                }}
+              >
+                Gap Analysis
+              </div>
+              <GapAnalysisTable gaps={submission.gap_analysis} />
+            </div>
+
+            {/* Action buttons */}
+            <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
+              <Button
+                variant="outline"
+                disabled
+                style={{ opacity: 0.5, cursor: "not-allowed" }}
+              >
+                Download Report (Coming Soon)
+              </Button>
+              <Link href="/submissions" style={{ textDecoration: "none" }}>
+                <Button variant="ghost">Back to History</Button>
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {/* Toast */}
+        {toast && (
+          <Toast
+            message={toast.message}
+            type={toast.type}
+            visible={!!toast}
+            onClose={() => setToast(null)}
+          />
+        )}
+      </div>
+    </main>
+  );
 }

--- a/src/app/(dashboard)/submissions/page.tsx
+++ b/src/app/(dashboard)/submissions/page.tsx
@@ -1,3 +1,664 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import type { SubmissionListItem } from "@/lib/validation/schemas";
+import Badge from "@/components/ui/Badge";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import Modal from "@/components/ui/Modal";
+import Skeleton from "@/components/ui/Skeleton";
+import Toast from "@/components/ui/Toast";
+import { getScoreColor } from "@/components/dashboard/utils";
+import type { Status } from "@/components/dashboard/utils";
+
+// ─── Style constants (matching ModelInventoryTable / GapAnalysisTable) ────────
+
+const TH_STYLE: React.CSSProperties = {
+  fontFamily: "var(--font-geist)",
+  fontSize: "10px",
+  fontWeight: 600,
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+  color: "var(--color-text-secondary)",
+  padding: "10px 12px",
+  textAlign: "left",
+  whiteSpace: "nowrap",
+  background: "var(--color-bg-tertiary)",
+  borderBottom: "1px solid var(--color-border)",
+};
+
+const TD_STYLE: React.CSSProperties = {
+  fontFamily: "var(--font-geist)",
+  fontSize: "13px",
+  color: "var(--color-text-primary)",
+  padding: "10px 12px",
+  borderBottom: "1px solid var(--color-border)",
+  whiteSpace: "nowrap",
+};
+
+const MONO_CELL: React.CSSProperties = {
+  fontFamily: "var(--font-ibm-plex-mono)",
+  fontSize: "13px",
+  fontWeight: 500,
+};
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+// ─── API response shape ──────────────────────────────────────────────────────
+
+interface SubmissionsResponse {
+  data: SubmissionListItem[];
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+// ─── Loading skeleton ────────────────────────────────────────────────────────
+
+function SubmissionsLoadingSkeleton() {
+  return (
+    <Card style={{ padding: 0, overflow: "hidden" }}>
+      <div
+        style={{
+          padding: "14px 20px",
+          background: "var(--color-bg-tertiary)",
+          display: "flex",
+          gap: "40px",
+        }}
+      >
+        {[120, 50, 80, 60, 100, 70].map((w, i) => (
+          <Skeleton key={i} width={w} height={10} />
+        ))}
+      </div>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            gap: "40px",
+            padding: "12px 20px",
+            borderBottom: "1px solid var(--color-border)",
+            opacity: 1 - i * 0.12,
+          }}
+        >
+          <Skeleton width={140} height={13} />
+          <Skeleton width={30} height={13} />
+          <Skeleton width={80} height={13} />
+          <Skeleton width={30} height={13} />
+          <Skeleton width={90} height={20} borderRadius={100} />
+          <Skeleton width={80} height={13} />
+        </div>
+      ))}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          padding: "14px 20px",
+          borderTop: "1px solid var(--color-border)",
+        }}
+      >
+        <Skeleton width={140} height={12} />
+        <div style={{ display: "flex", gap: "8px" }}>
+          <Skeleton width={50} height={24} />
+          <Skeleton width={50} height={24} />
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ─── Empty state ─────────────────────────────────────────────────────────────
+
+function EmptyState() {
+  return (
+    <Card animate delay={0.06}>
+      <div style={{ textAlign: "center", padding: "48px 0" }}>
+        <div
+          style={{
+            fontFamily: "var(--font-geist)",
+            fontSize: "13px",
+            color: "var(--color-text-secondary)",
+            marginBottom: "12px",
+          }}
+        >
+          No submissions yet — run your first compliance check.
+        </div>
+        <Link
+          href="/check"
+          style={{
+            fontFamily: "var(--font-geist)",
+            fontSize: "12px",
+            fontWeight: 500,
+            color: "var(--color-accent)",
+            textDecoration: "none",
+          }}
+        >
+          Start a compliance check &rarr;
+        </Link>
+      </div>
+    </Card>
+  );
+}
+
+// ─── Main page component ─────────────────────────────────────────────────────
+
 export default function SubmissionsPage() {
-  return null;
+  const [submissions, setSubmissions] = useState<SubmissionListItem[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const [deleteModal, setDeleteModal] = useState<
+    | { type: "single"; id: string; modelName: string }
+    | { type: "all" }
+    | null
+  >(null);
+  const [deleteAllConfirmText, setDeleteAllConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
+
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+
+  // Fetch paginated submissions
+  const fetchSubmissions = useCallback(async (p: number) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/submissions?page=${p}&limit=10`);
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          message?: string;
+        } | null;
+        setToast({
+          message: body?.message ?? "Failed to load submissions.",
+          type: "error",
+        });
+        setLoading(false);
+        return;
+      }
+      const json = (await res.json()) as SubmissionsResponse;
+      setSubmissions(json.data);
+      setTotal(json.total);
+      setTotalPages(json.totalPages);
+      setPage(json.page);
+    } catch {
+      setToast({
+        message: "Network error. Please check your connection.",
+        type: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSubmissions(1);
+  }, [fetchSubmissions]);
+
+  // Delete single submission
+  const handleDeleteSingle = useCallback(
+    async (id: string) => {
+      setDeleting(true);
+      try {
+        const res = await fetch(`/api/submissions/${id}`, {
+          method: "DELETE",
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as {
+            message?: string;
+          } | null;
+          setToast({
+            message: body?.message ?? "Failed to delete submission.",
+            type: "error",
+          });
+          return;
+        }
+        setToast({ message: "Submission deleted.", type: "success" });
+        setDeleteModal(null);
+        // If last item on current page, go back one page
+        const targetPage =
+          submissions.length === 1 && page > 1 ? page - 1 : page;
+        await fetchSubmissions(targetPage);
+      } catch {
+        setToast({
+          message: "Network error. Please try again.",
+          type: "error",
+        });
+      } finally {
+        setDeleting(false);
+      }
+    },
+    [fetchSubmissions, page, submissions.length]
+  );
+
+  // Delete all submissions
+  const handleDeleteAll = useCallback(async () => {
+    setDeleting(true);
+    try {
+      const res = await fetch("/api/submissions", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: true }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          message?: string;
+        } | null;
+        setToast({
+          message: body?.message ?? "Failed to delete history.",
+          type: "error",
+        });
+        return;
+      }
+      setToast({ message: "All submission history deleted.", type: "success" });
+      setDeleteModal(null);
+      setDeleteAllConfirmText("");
+      await fetchSubmissions(1);
+    } catch {
+      setToast({
+        message: "Network error. Please try again.",
+        type: "error",
+      });
+    } finally {
+      setDeleting(false);
+    }
+  }, [fetchSubmissions]);
+
+  const showingStart = total > 0 ? (page - 1) * 10 + 1 : 0;
+  const showingEnd = Math.min(page * 10, total);
+
+  return (
+    <main
+      style={{
+        background: "var(--color-bg-primary)",
+        minHeight: "100vh",
+        padding: "32px 20px",
+      }}
+    >
+      <div style={{ maxWidth: 900, margin: "0 auto" }}>
+        {/* Page header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            flexWrap: "wrap",
+            gap: "16px",
+            marginBottom: "32px",
+          }}
+        >
+          <div>
+            <h1
+              style={{
+                fontFamily: "var(--font-playfair)",
+                fontSize: "28px",
+                fontWeight: 700,
+                color: "var(--color-text-primary)",
+                margin: "0 0 6px 0",
+                lineHeight: 1.2,
+              }}
+            >
+              Submission History
+            </h1>
+            <p
+              style={{
+                fontFamily: "var(--font-geist)",
+                fontSize: "14px",
+                color: "var(--color-text-secondary)",
+                margin: 0,
+              }}
+            >
+              Review and manage your compliance check history.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={total === 0 || loading}
+            onClick={() => setDeleteModal({ type: "all" })}
+            style={{
+              color: "var(--color-critical)",
+              borderColor:
+                "color-mix(in srgb, var(--color-critical) 40%, transparent)",
+            }}
+          >
+            Delete All History
+          </Button>
+        </div>
+
+        {/* Loading skeleton */}
+        {loading && <SubmissionsLoadingSkeleton />}
+
+        {/* Empty state */}
+        {!loading && submissions.length === 0 && <EmptyState />}
+
+        {/* Table */}
+        {!loading && submissions.length > 0 && (
+          <Card
+            animate
+            delay={0.06}
+            style={{ padding: 0, overflow: "hidden" }}
+          >
+            <div style={{ overflowX: "auto" }}>
+              <table
+                style={{
+                  width: "100%",
+                  borderCollapse: "collapse",
+                  borderRadius: 0,
+                }}
+              >
+                <thead>
+                  <tr>
+                    <th style={TH_STYLE}>Model Name</th>
+                    <th style={TH_STYLE}>Version</th>
+                    <th style={TH_STYLE}>Date</th>
+                    <th style={TH_STYLE}>Final Score</th>
+                    <th style={TH_STYLE}>Status</th>
+                    <th style={TH_STYLE}>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {submissions.map((sub, i) => (
+                    <motion.tr
+                      key={sub.id}
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      transition={{ duration: 0.25, delay: i * 0.03 }}
+                      style={{ background: "transparent" }}
+                    >
+                      <td
+                        style={{
+                          ...TD_STYLE,
+                          maxWidth: "200px",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                        }}
+                      >
+                        {sub.model_name}
+                      </td>
+                      <td style={{ ...TD_STYLE, ...MONO_CELL }}>
+                        v{sub.version_number}
+                      </td>
+                      <td
+                        style={{
+                          ...TD_STYLE,
+                          fontSize: "12px",
+                          color: "var(--color-text-secondary)",
+                        }}
+                      >
+                        {formatDate(sub.created_at)}
+                      </td>
+                      <td
+                        style={{
+                          ...TD_STYLE,
+                          ...MONO_CELL,
+                          fontWeight: 600,
+                          color: getScoreColor(sub.final_score),
+                        }}
+                      >
+                        {Math.round(sub.final_score)}
+                      </td>
+                      <td style={TD_STYLE}>
+                        <Badge status={sub.status as Status} />
+                      </td>
+                      <td style={TD_STYLE}>
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px",
+                          }}
+                        >
+                          <Link
+                            href={`/submissions/${sub.id}`}
+                            style={{
+                              fontFamily: "var(--font-geist)",
+                              fontSize: "11px",
+                              fontWeight: 500,
+                              color: "var(--color-accent)",
+                              textDecoration: "none",
+                            }}
+                          >
+                            View
+                          </Link>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() =>
+                              setDeleteModal({
+                                type: "single",
+                                id: sub.id,
+                                modelName: sub.model_name,
+                              })
+                            }
+                            style={{
+                              fontFamily: "var(--font-geist)",
+                              fontSize: "11px",
+                              padding: "2px 6px",
+                              color: "var(--color-critical)",
+                            }}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </td>
+                    </motion.tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Pagination footer */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: "14px 20px",
+                borderTop: "1px solid var(--color-border)",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--font-geist)",
+                  fontSize: "12px",
+                  color: "var(--color-text-secondary)",
+                }}
+              >
+                Showing {showingStart}&ndash;{showingEnd} of {total}
+              </span>
+              <div style={{ display: "flex", gap: "8px" }}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => fetchSubmissions(page - 1)}
+                >
+                  Prev
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => fetchSubmissions(page + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {/* Delete single modal */}
+        <Modal
+          open={deleteModal?.type === "single"}
+          onClose={() => setDeleteModal(null)}
+          title="Delete Submission"
+        >
+          <p
+            style={{
+              fontFamily: "var(--font-geist)",
+              fontSize: "13px",
+              color: "var(--color-text-secondary)",
+              margin: "0 0 6px 0",
+              lineHeight: 1.5,
+            }}
+          >
+            Are you sure you want to delete the submission for{" "}
+            <strong style={{ color: "var(--color-text-primary)" }}>
+              {deleteModal?.type === "single" ? deleteModal.modelName : ""}
+            </strong>
+            ?
+          </p>
+          <p
+            style={{
+              fontFamily: "var(--font-geist)",
+              fontSize: "12px",
+              color: "var(--color-text-secondary)",
+              margin: 0,
+            }}
+          >
+            This action cannot be undone.
+          </p>
+          <div
+            style={{
+              display: "flex",
+              gap: "12px",
+              marginTop: "20px",
+              justifyContent: "flex-end",
+            }}
+          >
+            <Button
+              variant="ghost"
+              onClick={() => setDeleteModal(null)}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => {
+                if (deleteModal?.type === "single") {
+                  handleDeleteSingle(deleteModal.id);
+                }
+              }}
+              disabled={deleting}
+              style={{
+                background: "var(--color-critical)",
+                borderColor: "var(--color-critical)",
+              }}
+            >
+              {deleting ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </Modal>
+
+        {/* Delete all modal */}
+        <Modal
+          open={deleteModal?.type === "all"}
+          onClose={() => {
+            setDeleteModal(null);
+            setDeleteAllConfirmText("");
+          }}
+          title="Delete All History"
+        >
+          <p
+            style={{
+              fontFamily: "var(--font-geist)",
+              fontSize: "13px",
+              color: "var(--color-text-secondary)",
+              margin: "0 0 12px 0",
+              lineHeight: 1.5,
+            }}
+          >
+            This will permanently delete all{" "}
+            <strong style={{ color: "var(--color-text-primary)" }}>
+              {total}
+            </strong>{" "}
+            submission{total !== 1 ? "s" : ""}. This action cannot be undone.
+          </p>
+          <p
+            style={{
+              fontFamily: "var(--font-geist)",
+              fontSize: "12px",
+              color: "var(--color-text-secondary)",
+              margin: "0 0 8px 0",
+            }}
+          >
+            Type <strong style={{ color: "var(--color-text-primary)" }}>DELETE</strong>{" "}
+            to confirm:
+          </p>
+          <input
+            type="text"
+            value={deleteAllConfirmText}
+            onChange={(e) => setDeleteAllConfirmText(e.target.value)}
+            placeholder="DELETE"
+            style={{
+              fontFamily: "var(--font-geist)",
+              fontSize: "12px",
+              color: "var(--color-text-primary)",
+              background: "var(--color-bg-tertiary)",
+              border: "1px solid var(--color-border)",
+              borderRadius: "2px",
+              padding: "8px 12px",
+              width: "100%",
+              outline: "none",
+            }}
+          />
+          <div
+            style={{
+              display: "flex",
+              gap: "12px",
+              marginTop: "20px",
+              justifyContent: "flex-end",
+            }}
+          >
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setDeleteModal(null);
+                setDeleteAllConfirmText("");
+              }}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleDeleteAll}
+              disabled={deleting || deleteAllConfirmText !== "DELETE"}
+              style={{
+                background: "var(--color-critical)",
+                borderColor: "var(--color-critical)",
+              }}
+            >
+              {deleting ? "Deleting..." : "Delete All"}
+            </Button>
+          </div>
+        </Modal>
+
+        {/* Toast */}
+        {toast && (
+          <Toast
+            message={toast.message}
+            type={toast.type}
+            visible={!!toast}
+            onClose={() => setToast(null)}
+          />
+        )}
+      </div>
+    </main>
+  );
 }

--- a/src/app/api/submissions/[id]/route.ts
+++ b/src/app/api/submissions/[id]/route.ts
@@ -1,10 +1,154 @@
-import { createServerClient } from "@/lib/supabase/server";
-import { errorResponse } from "@/lib/errors/messages";
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import { createServerClient } from '@/lib/supabase/server';
+import { errorResponse } from '@/lib/errors/messages';
+import { UuidParamSchema } from '@/lib/validation/schemas';
+import type { SubmissionDetail, Gap } from '@/lib/validation/schemas';
 
-export async function GET() {
+type Status = 'Compliant' | 'Needs Improvement' | 'Critical Gaps';
+
+function deriveStatus(score: number): Status {
+  if (score >= 80) return 'Compliant';
+  if (score >= 60) return 'Needs Improvement';
+  return 'Critical Gaps';
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const supabase = await createServerClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return errorResponse("AUTH_REQUIRED");
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  return Response.json({ error: "Not implemented" }, { status: 501 });
+  if (!user) {
+    return errorResponse('AUTH_REQUIRED');
+  }
+
+  // Validate UUID param
+  const { id } = await params;
+  const parsed = UuidParamSchema.safeParse({ id });
+  if (!parsed.success) {
+    return errorResponse('VALIDATION_ERROR', {
+      message: parsed.error.issues[0]?.message ?? 'Invalid submission ID.',
+    });
+  }
+
+  const submissionId = parsed.data.id;
+
+  try {
+    // Fetch submission with model name join
+    const { data: row, error: fetchError } = await supabase
+      .from('submissions')
+      .select(
+        'id, user_id, version_number, document_text, conceptual_score, outcomes_score, monitoring_score, final_score, judge_confidence, assessment_confidence_label, created_at, models(model_name)'
+      )
+      .eq('id', submissionId)
+      .maybeSingle();
+
+    if (fetchError) {
+      Sentry.captureException(fetchError);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    // Not found or wrong user (defense in depth — RLS handles it too)
+    if (!row || row.user_id !== user.id) {
+      return errorResponse('SUBMISSION_NOT_FOUND');
+    }
+
+    // Fetch gaps from normalized table
+    const { data: gapRows, error: gapsError } = await supabase
+      .from('gaps')
+      .select('element_code, element_name, severity, description, recommendation')
+      .eq('submission_id', submissionId);
+
+    if (gapsError) {
+      Sentry.captureException(gapsError);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    const models = row.models as unknown as { model_name: string } | null;
+    const finalScore = Number(row.final_score);
+
+    const detail: SubmissionDetail = {
+      id: row.id,
+      model_name: models?.model_name ?? 'Unknown',
+      version_number: row.version_number,
+      conceptual_score: Number(row.conceptual_score),
+      outcomes_score: Number(row.outcomes_score),
+      monitoring_score: Number(row.monitoring_score),
+      final_score: finalScore,
+      status: deriveStatus(finalScore),
+      assessment_confidence_label: row.assessment_confidence_label as SubmissionDetail['assessment_confidence_label'],
+      created_at: row.created_at,
+      document_text: row.document_text,
+      gap_analysis: (gapRows ?? []) as Gap[],
+      judge_confidence: Number(row.judge_confidence),
+    };
+
+    return NextResponse.json(detail);
+  } catch (err) {
+    Sentry.captureException(err);
+    return errorResponse('DATABASE_ERROR');
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return errorResponse('AUTH_REQUIRED');
+  }
+
+  // Validate UUID param
+  const { id } = await params;
+  const parsed = UuidParamSchema.safeParse({ id });
+  if (!parsed.success) {
+    return errorResponse('VALIDATION_ERROR', {
+      message: parsed.error.issues[0]?.message ?? 'Invalid submission ID.',
+    });
+  }
+
+  const submissionId = parsed.data.id;
+
+  try {
+    // Verify existence and ownership (defense in depth)
+    const { data: row, error: fetchError } = await supabase
+      .from('submissions')
+      .select('id, user_id')
+      .eq('id', submissionId)
+      .maybeSingle();
+
+    if (fetchError) {
+      Sentry.captureException(fetchError);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    if (!row || row.user_id !== user.id) {
+      return errorResponse('SUBMISSION_NOT_FOUND');
+    }
+
+    // Hard delete — FK CASCADE handles gaps and evals
+    const { error: deleteError } = await supabase
+      .from('submissions')
+      .delete()
+      .eq('id', submissionId);
+
+    if (deleteError) {
+      Sentry.captureException(deleteError);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    Sentry.captureException(err);
+    return errorResponse('DATABASE_ERROR');
+  }
 }

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -1,10 +1,144 @@
-import { createServerClient } from "@/lib/supabase/server";
-import { errorResponse } from "@/lib/errors/messages";
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import { createServerClient } from '@/lib/supabase/server';
+import { errorResponse } from '@/lib/errors/messages';
+import {
+  PaginationParamsSchema,
+  DeleteAllConfirmSchema,
+} from '@/lib/validation/schemas';
+import type { SubmissionListItem } from '@/lib/validation/schemas';
 
-export async function GET() {
+type Status = 'Compliant' | 'Needs Improvement' | 'Critical Gaps';
+
+function deriveStatus(score: number): Status {
+  if (score >= 80) return 'Compliant';
+  if (score >= 60) return 'Needs Improvement';
+  return 'Critical Gaps';
+}
+
+export async function GET(request: Request) {
   const supabase = await createServerClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return errorResponse("AUTH_REQUIRED");
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  return Response.json({ error: "Not implemented" }, { status: 501 });
+  if (!user) {
+    return errorResponse('AUTH_REQUIRED');
+  }
+
+  // Parse and validate pagination params
+  const { searchParams } = new URL(request.url);
+  const parsed = PaginationParamsSchema.safeParse({
+    page: searchParams.get('page') ?? undefined,
+    limit: searchParams.get('limit') ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return errorResponse('VALIDATION_ERROR', {
+      message: parsed.error.issues[0]?.message ?? 'Invalid pagination parameters.',
+    });
+  }
+
+  const { page, limit } = parsed.data;
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  try {
+    // Count query for pagination metadata
+    const { count, error: countError } = await supabase
+      .from('submissions')
+      .select('id', { count: 'exact', head: true });
+
+    if (countError) {
+      Sentry.captureException(countError);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    const total = count ?? 0;
+
+    // Data query with model name join
+    const { data: rows, error: dataError } = await supabase
+      .from('submissions')
+      .select(
+        'id, version_number, conceptual_score, outcomes_score, monitoring_score, final_score, assessment_confidence_label, created_at, models(model_name)'
+      )
+      .order('created_at', { ascending: false })
+      .range(from, to);
+
+    if (dataError) {
+      Sentry.captureException(dataError);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    // Transform rows to match SubmissionListItemSchema
+    const data: SubmissionListItem[] = (rows ?? []).map((row) => {
+      const models = row.models as unknown as { model_name: string } | null;
+      const finalScore = Number(row.final_score);
+
+      return {
+        id: row.id,
+        model_name: models?.model_name ?? 'Unknown',
+        version_number: row.version_number,
+        conceptual_score: Number(row.conceptual_score),
+        outcomes_score: Number(row.outcomes_score),
+        monitoring_score: Number(row.monitoring_score),
+        final_score: finalScore,
+        status: deriveStatus(finalScore),
+        assessment_confidence_label: row.assessment_confidence_label as SubmissionListItem['assessment_confidence_label'],
+        created_at: row.created_at,
+      };
+    });
+
+    const totalPages = Math.ceil(total / limit);
+
+    return NextResponse.json({ data, page, limit, total, totalPages });
+  } catch (err) {
+    Sentry.captureException(err);
+    return errorResponse('DATABASE_ERROR');
+  }
+}
+
+export async function DELETE(request: Request) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return errorResponse('AUTH_REQUIRED');
+  }
+
+  // Require explicit confirmation
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('VALIDATION_ERROR', {
+      message: 'Request body must be valid JSON.',
+    });
+  }
+
+  const parsed = DeleteAllConfirmSchema.safeParse(body);
+  if (!parsed.success) {
+    return errorResponse('VALIDATION_ERROR', {
+      message: parsed.error.issues[0]?.message ?? 'Confirmation required.',
+    });
+  }
+
+  try {
+    const { error } = await supabase
+      .from('submissions')
+      .delete()
+      .eq('user_id', user.id);
+
+    if (error) {
+      Sentry.captureException(error);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    Sentry.captureException(err);
+    return errorResponse('DATABASE_ERROR');
+  }
 }

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -313,3 +313,24 @@ export const ErrorResponseSchema = z.object({
 });
 
 export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+
+// ─── Pagination & param schemas ─────────────────────────────────────────────
+
+export const PaginationParamsSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+export type PaginationParams = z.infer<typeof PaginationParamsSchema>;
+
+export const UuidParamSchema = z.object({
+  id: z.string().uuid("Invalid submission ID"),
+});
+
+export type UuidParam = z.infer<typeof UuidParamSchema>;
+
+export const DeleteAllConfirmSchema = z.object({
+  confirm: z.literal(true, { message: "Confirmation required" }),
+});
+
+export type DeleteAllConfirm = z.infer<typeof DeleteAllConfirmSchema>;


### PR DESCRIPTION
## S2-06: Submission History and Single Submission View

### Backend — API Routes
- **GET /api/submissions** — paginated list with models join, `Number()` wrapping for Supabase NUMERIC columns, derived status, pagination metadata (`page`, `limit`, `total`, `totalPages`)
- **GET /api/submissions/[id]** — full submission detail with gaps from normalized table, defense-in-depth ownership check, `.maybeSingle()` for clean 404 handling
- **DELETE /api/submissions/[id]** — ownership verification then hard delete (FK CASCADE handles gaps + evals)
- **DELETE /api/submissions** — requires `{ confirm: true }` body, deletes all user submissions

New Zod schemas: `PaginationParamsSchema` (coerced page/limit), `UuidParamSchema`, `DeleteAllConfirmSchema` (`z.literal(true)`)

### Frontend — Pages
- **/submissions** — paginated table (Model Name, Version, Date, Score, Status, Actions), single-delete modal with model name, bulk-delete modal requiring typed "DELETE", empty state, skeleton loading, auto-refetch after deletes, page-back on last-item deletion
- **/submissions/[id]** — full detail view reusing `PillarScoreCard` + `GapAnalysisTable` directly (Option A — honest about available data, no faked ComplianceResponse), confidence badge, low-confidence warning banner, 404 handling, skeleton loading

### Testing
- `npm run build` ✅
- `npm run typecheck` ✅

Closes #S2-06