### PR TITLE
fix: resolve lint errors caught by CI pipeline

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -40,7 +40,7 @@ export default function SettingsPage() {
   const [deleting, setDeleting] = useState(false);
 
   // Password recovery
-  const [recoveryMode, setRecoveryMode] = useState(false);
+  const [recoveryMode, setRecoveryMode] = useState(searchParams.get("type") === "recovery");
   const [newPassword, setNewPassword] = useState("");
   const [confirmNewPassword, setConfirmNewPassword] = useState("");
   const [updatingPassword, setUpdatingPassword] = useState(false);
@@ -71,11 +71,6 @@ export default function SettingsPage() {
     }
 
     init();
-
-    // Check for recovery mode via URL param
-    if (searchParams.get("type") === "recovery") {
-      setRecoveryMode(true);
-    }
 
     // Listen for PASSWORD_RECOVERY auth event
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {

--- a/src/components/dashboard/ModelInventoryTable.tsx
+++ b/src/components/dashboard/ModelInventoryTable.tsx
@@ -52,13 +52,6 @@ const INPUT_STYLE: React.CSSProperties = {
   padding: "5px 10px",
 };
 
-function toDateInputValue(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
 /** Parse a YYYY-MM-DD string to a Date at midnight local */
 function parseDateInput(value: string): Date | null {
   if (!value) return null;

--- a/src/lib/agents/orchestrator.ts
+++ b/src/lib/agents/orchestrator.ts
@@ -26,7 +26,6 @@ export async function runCompliance(
   let retryCount = 0;
   let previousIssues: string[] = [];
 
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const retryContext = retryCount > 0 ? buildRetryContext(retryCount, previousIssues) : undefined;
 

--- a/src/lib/validation/schemas.test.ts
+++ b/src/lib/validation/schemas.test.ts
@@ -385,6 +385,7 @@ describe("JudgeOutputSchema", () => {
 
   it("rejects missing agent_feedback pillar", () => {
     const { agent_feedback: { ongoing_monitoring: _om, ...feedbackRest } } = validJudge;
+    void _om;
     expect(
       JudgeOutputSchema.safeParse({ ...validJudge, agent_feedback: feedbackRest }).success
     ).toBe(false);
@@ -564,7 +565,8 @@ describe("ComplianceResponseSchema", () => {
   });
 
   it("rejects a missing created_at field", () => {
-    const { created_at: _, ...withoutDate } = validResponse;
+    const { created_at: _createdAt, ...withoutDate } = validResponse;
+    void _createdAt;
     expect(ComplianceResponseSchema.safeParse(withoutDate).success).toBe(false);
   });
 });
@@ -837,7 +839,8 @@ describe("PillarScoresSchema", () => {
   });
 
   it("rejects a missing pillar", () => {
-    const { ongoing_monitoring: _, ...partial } = validScores;
+    const { ongoing_monitoring: _om, ...partial } = validScores;
+    void _om;
     expect(PillarScoresSchema.safeParse(partial).success).toBe(false);
   });
 });
@@ -881,7 +884,8 @@ describe("SubmissionDetailSchema", () => {
   });
 
   it("rejects missing document_text", () => {
-    const { document_text: _, ...withoutText } = validDetail;
+    const { document_text: _docText, ...withoutText } = validDetail;
+    void _docText;
     expect(SubmissionDetailSchema.safeParse(withoutText).success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Move `searchParams` recovery check from `useEffect` to `useState` initializer in settings page
- Remove unused `toDateInputValue` function from `ModelInventoryTable`
- Remove unnecessary `eslint-disable` directive in orchestrator
- Fix unused destructured variables in schema tests with `void` expressions

## Test plan
- [x] `npm run lint` passes with zero errors and zero warnings
- [ ] `npm run typecheck` passes
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)