### PR TITLE
refactor: replace pdf-parse with unpdf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ RATE_LIMIT_REQUESTS_PER_HOUR   # Default: 10
 ---
 
 ## Stack at a Glance
-Next.js 16 App Router · TypeScript strict · Supabase (PostgreSQL + Auth + RLS) · Anthropic Claude Haiku 3.5 · `@react-pdf/renderer` · `pdf-parse` · `mammoth` · Zod · Tailwind CSS · Recharts · Sentry · Vercel
+Next.js 16 App Router · TypeScript strict · Supabase (PostgreSQL + Auth + RLS) · Anthropic Claude Haiku 3.5 · `@react-pdf/renderer` · `unpdf` · `mammoth` · Zod · Tailwind CSS · Recharts · Sentry · Vercel
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Upload / paste model documentation
 | Auth & Database | Supabase (PostgreSQL + Auth + Row Level Security) |
 | AI | Anthropic Claude Haiku 4.5 (`claude-haiku-4-5-20251001`) |
 | PDF | `@react-pdf/renderer` |
-| Document parsing | `pdf-parse` (PDF) · `mammoth` (DOCX) |
+| Document parsing | `unpdf` (PDF) · `mammoth` (DOCX) |
 | Validation | Zod — all schemas in `src/lib/validation/schemas.ts` |
 | Styling | Tailwind CSS · Playfair Display · IBM Plex Mono · Geist |
 | Charts | Recharts |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,7 @@ User submits document
 │  2. Check rate limit (user ID + timestamp)             │
 │  3. Validate request body (Zod: ComplianceRequest)     │
 │  4. Parse file if uploaded:                            │
-│     - PDF  → pdf-parse → extracted text               │
+│     - PDF  → unpdf     → extracted text               │
 │     - DOCX → mammoth   → extracted text               │
 │     - File deleted from memory immediately             │
 │  5. Sanitize text (strip HTML, scripts)                │

--- a/docs/ERROR_STATES.md
+++ b/docs/ERROR_STATES.md
@@ -115,7 +115,7 @@ Implement all error states exactly as defined here — do not invent error messa
 ---
 
 ### FILE_PARSE_FAILED
-**Trigger:** `pdf-parse` or `mammoth` fails to extract text from a valid file type.
+**Trigger:** `unpdf` or `mammoth` fails to extract text from a valid file type.
 **HTTP:** 422
 **User-facing message:** "Could not read this file. Try pasting your document text directly instead."
 **UI behavior:** Inline error. "Switch to text input" button shown prominently as recovery action.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -308,7 +308,7 @@ Every agent output validated against Zod schema before passing to next stage. Sc
 | Authentication | Supabase Auth |
 | AI | Anthropic Claude Haiku 3.5 |
 | PDF Generation | React-PDF (`@react-pdf/renderer`) |
-| PDF Parsing | `pdf-parse` |
+| PDF Parsing | `unpdf` |
 | DOCX Parsing | `mammoth` |
 | Schema Validation | Zod |
 | Error Tracking | Sentry |
@@ -338,7 +338,7 @@ POST /api/compliance
   1. Verify authenticated session (server-side)
   2. Check rate limit for user
   3. Validate request body against Zod schema
-  4. If file: extract text via pdf-parse or mammoth, delete file from memory
+  4. If file: extract text via unpdf or mammoth, delete file from memory
   5. Sanitize text: strip HTML, script tags
   6. Wrap text in XML delimiters
   7. Fire three agents in parallel (Promise.all):

--- a/docs/TECHNICAL_SPECS.md
+++ b/docs/TECHNICAL_SPECS.md
@@ -114,7 +114,7 @@ prova/
 │   │   │   └── calculator.ts             Scoring math — pillar scores + final weighted score
 │   │   │
 │   │   ├── parsers/
-│   │   │   ├── pdf.ts                    pdf-parse wrapper
+│   │   │   ├── pdf.ts                    unpdf wrapper
 │   │   │   └── docx.ts                   mammoth wrapper
 │   │   │
 │   │   ├── validation/

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,27 +1,4 @@
 export async function register() {
-  // Polyfill DOM globals that pdfjs-dist expects but don't exist in
-  // Vercel's serverless Node.js runtime. We do this here in instrumentation
-  // to guarantee they are polyfilled universally before any routes evaluate.
-  if (typeof globalThis.DOMMatrix === "undefined") {
-    (globalThis as Record<string, unknown>).DOMMatrix = class DOMMatrix {};
-  }
-  if (typeof globalThis.Path2D === "undefined") {
-    (globalThis as Record<string, unknown>).Path2D = class Path2D {};
-  }
-  if (typeof globalThis.ImageData === "undefined") {
-    (globalThis as Record<string, unknown>).ImageData = class ImageData {
-      data: Uint8ClampedArray;
-      width: number;
-      height: number;
-      constructor(width: number, height: number) {
-        this.data = new Uint8ClampedArray(width * height * 4);
-        this.width = width;
-        this.height = height;
-      }
-    };
-  }
-
-
   if (process.env.NODE_ENV !== "production" || !process.env.SENTRY_DSN) {
     return;
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,7 @@ const scriptSrc = [
 ].join(" ");
 
 const nextConfig: NextConfig = {
-  serverExternalPackages: ["mammoth", "@react-pdf/renderer", "pdf-parse", "pdfjs-dist"],
+  serverExternalPackages: ["mammoth", "@react-pdf/renderer"],
   outputFileTracingIncludes: {
     "/api/report": ["./public/fonts/pdf/**/*"],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,17 +18,16 @@
         "lenis": "^1.3.19",
         "mammoth": "^1.12.0",
         "next": "^16.2.1",
-        "pdf-parse": "^2.4.5",
         "react": "^18",
         "react-dom": "^18",
         "recharts": "^3.8.0",
         "server-only": "^0.0.1",
+        "unpdf": "^1.4.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
-        "@types/pdf-parse": "^1.1.5",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^9.39.4",
@@ -2338,190 +2337,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@napi-rs/canvas": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
-      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
-      "license": "MIT",
-      "workspaces": [
-        "e2e/*"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.80",
-        "@napi-rs/canvas-darwin-arm64": "0.1.80",
-        "@napi-rs/canvas-darwin-x64": "0.1.80",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
-      }
-    },
-    "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
-      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
-      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
-      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
-      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
-      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
-      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
-      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
-      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
-      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
-      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4966,16 +4781,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/pdf-parse": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
-      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -11851,38 +11656,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/pdf-parse": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
-      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@napi-rs/canvas": "0.1.80",
-        "pdfjs-dist": "5.4.296"
-      },
-      "bin": {
-        "pdf-parse": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": ">=20.16.0 <21 || >=22.3.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/mehmet-kozan"
-      }
-    },
-    "node_modules/pdfjs-dist": {
-      "version": "5.4.296",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
-      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.16.0 || >=22.3.0"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.80"
-      }
-    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -14287,6 +14060,20 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
+    },
+    "node_modules/unpdf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.4.0.tgz",
+      "integrity": "sha512-TahIk0xdH/4jh/MxfclzU79g40OyxtP00VnEUZdEkJoYtXAHWLiir6t3FC6z3vDqQTzc2ZHcla6uEiVTNjejuA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -22,17 +22,16 @@
     "lenis": "^1.3.19",
     "mammoth": "^1.12.0",
     "next": "^16.2.1",
-    "pdf-parse": "^2.4.5",
     "react": "^18",
     "react-dom": "^18",
     "recharts": "^3.8.0",
     "server-only": "^0.0.1",
+    "unpdf": "^1.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
-    "@types/pdf-parse": "^1.1.5",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^9.39.4",

--- a/src/lib/parsers/pdf.test.ts
+++ b/src/lib/parsers/pdf.test.ts
@@ -1,27 +1,28 @@
 import { parsePDF, PDFParseError } from "./pdf";
 
-// pdf-parse v2 uses workers that require --experimental-vm-modules and cannot
-// run natively in Jest. It is an external system boundary so mocking is correct.
-jest.mock("pdf-parse/worker", () => ({
-  CanvasFactory: jest.fn(),
+// unpdf is an external system boundary so mocking is correct.
+const mockCleanup = jest.fn();
+const mockGetDocumentProxy = jest.fn();
+const mockExtractText = jest.fn();
+
+jest.mock("unpdf", () => ({
+  getDocumentProxy: (...args: unknown[]) => mockGetDocumentProxy(...args),
+  extractText: (...args: unknown[]) => mockExtractText(...args),
 }));
 
-jest.mock("pdf-parse", () => ({
-  PDFParse: jest.fn().mockImplementation(({ data }: { data: Buffer }) => ({
-    load: jest.fn().mockResolvedValue(undefined),
-    getText: jest.fn().mockImplementation(async () => {
-      if (!data || data.length === 0) throw new Error("Empty PDF");
-      return { text: "Extracted PDF text" };
-    }),
-    destroy: jest.fn().mockResolvedValue(undefined),
-  })),
-}));
+beforeEach(() => {
+  mockCleanup.mockReset();
+  mockGetDocumentProxy.mockReset().mockResolvedValue({ cleanup: mockCleanup });
+  mockExtractText.mockReset().mockResolvedValue({ text: "Extracted PDF text" });
+});
 
 describe("parsePDF", () => {
   it("returns a string from a valid PDF buffer", async () => {
     const result = await parsePDF(Buffer.from("%PDF-1.4 fake content"));
     expect(typeof result).toBe("string");
     expect(result).toBe("Extracted PDF text");
+    expect(mockGetDocumentProxy).toHaveBeenCalledWith(expect.any(Uint8Array));
+    expect(mockCleanup).toHaveBeenCalled();
   });
 
   it("does not accept a file path — only a Buffer", async () => {
@@ -31,12 +32,7 @@ describe("parsePDF", () => {
   });
 
   it("throws a PDFParseError on library failure", async () => {
-    const { PDFParse } = await import("pdf-parse");
-    (PDFParse as unknown as jest.Mock).mockImplementationOnce(() => ({
-      load: jest.fn().mockResolvedValue(undefined),
-      getText: jest.fn().mockRejectedValue(new Error("corrupt PDF")),
-      destroy: jest.fn().mockResolvedValue(undefined),
-    }));
+    mockGetDocumentProxy.mockRejectedValueOnce(new Error("corrupt PDF"));
 
     await expect(parsePDF(Buffer.from("bad"))).rejects.toThrow(PDFParseError);
   });

--- a/src/lib/parsers/pdf.ts
+++ b/src/lib/parsers/pdf.ts
@@ -16,18 +16,10 @@ export async function parsePDF(buffer: Buffer): Promise<string> {
     throw new PDFParseError("parsePDF requires a Buffer, not a file path");
   }
 
-  // Dynamic import ensures polyfills run before pdf-parse and pdfjs-dist are evaluated
-  // Official configuration for Next.js/Vercel serverless environments
-  // https://github.com/mehmet-kozan/pdf-parse/blob/main/docs/troubleshooting.md
-  const { CanvasFactory } = await import("pdf-parse/worker");
-  const { PDFParse } = await import("pdf-parse");
+  const { getDocumentProxy, extractText } = await import("unpdf");
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let parser: any;
   let timeoutHandle: NodeJS.Timeout | null = null;
   try {
-    parser = new PDFParse({ data: buffer, CanvasFactory });
-
     const timeout = new Promise<never>((_resolve, reject) => {
       timeoutHandle = setTimeout(
         () => reject(new PDFParseError(`PDF parsing timed out after ${PARSE_TIMEOUT_MS}ms`)),
@@ -35,9 +27,16 @@ export async function parsePDF(buffer: Buffer): Promise<string> {
       );
     });
 
-    await Promise.race([parser.load(), timeout]);
-    const result = await Promise.race([parser.getText(), timeout]);
-    return result.text;
+    const pdf = await Promise.race([
+      getDocumentProxy(new Uint8Array(buffer)),
+      timeout,
+    ]);
+    const { text } = await Promise.race([
+      extractText(pdf, { mergePages: true }),
+      timeout,
+    ]);
+    pdf.cleanup();
+    return text;
   } catch (err) {
     if (err instanceof PDFParseError) throw err;
     throw new PDFParseError(
@@ -45,12 +44,5 @@ export async function parsePDF(buffer: Buffer): Promise<string> {
     );
   } finally {
     if (timeoutHandle !== null) clearTimeout(timeoutHandle);
-    if (parser?.destroy) {
-      try {
-        await parser.destroy();
-      } catch {
-        // Cleanup failure must not mask the original error
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Replaced `pdf-parse` (21.3 MB, DOM polyfills required) with `unpdf` (1.8 MB, zero DOM dependencies) for serverless-friendly PDF text extraction
- Removed DOMMatrix, Path2D, and ImageData polyfill stubs from `instrumentation.ts`
- Removed `pdf-parse` and `pdfjs-dist` from `serverExternalPackages` in `next.config.ts`
- Updated all documentation references across 6 markdown files

## Test plan
- [x] `npm test` — 248/248 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — successful production build
- [x] Manual test: upload a PDF file via the compliance check flow on preview deployment
- [ ] Verify Vercel deployment has no runtime errors related to PDF parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)