### PR TITLE
ci: add Playwright E2E, Gitleaks secret scanning, and AI PR review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   review:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,30 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-haiku-4-5-20251001
+          direct_prompt: |
+            Review this PR for:
+            1. TypeScript strict mode compliance (no any types)
+            2. All Zod schemas in src/lib/validation/schemas.ts only
+            3. All error messages from src/lib/errors/messages.ts
+            4. No dangerouslySetInnerHTML
+            5. No hardcoded secrets or API keys
+            6. Security: auth checks on all API routes, input validation
+            Provide a concise review with any issues found.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
       NEXT_PUBLIC_SENTRY_DSN: ""
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,14 @@ jobs:
       - run: npm run test:ai
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: npm run test:e2e
+      - name: Gitleaks secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build
         env:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,8 @@ jobs:
       NEXT_PUBLIC_SENTRY_DSN: ""
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,4 +28,12 @@ jobs:
       - run: npm run test:ai
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: npm run test:e2e
+      - name: Gitleaks secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ pnpm-debug.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # Claude Code
 .claude/worktrees/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/pdf-parse": "^1.1.5",
@@ -3279,6 +3280,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -12020,6 +12037,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:ai": "jest --config jest.ai.config.ts --verbose"
+    "test:ai": "jest --config jest.ai.config.ts --verbose",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
@@ -30,6 +31,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/pdf-parse": "^1.1.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30000,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:3000",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+  webServer: {
+    command: "npm run build && npx next start",
+    port: 3000,
+    reuseExistingServer: true,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL:
+        process.env.NEXT_PUBLIC_SUPABASE_URL ||
+        "https://placeholder.supabase.co",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY:
+        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ||
+        "placeholder",
+      NEXT_PUBLIC_APP_URL:
+        process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
+      NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN || "",
+    },
+  },
+});

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Landing Page", () => {
+  test("renders key elements", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page).toHaveTitle(/Prova/);
+
+    await expect(page.getByText("Know what's missing")).toBeVisible();
+
+    const ctaButton = page.getByRole("link", { name: /Start checking/i });
+    await expect(ctaButton).toBeVisible();
+    await expect(ctaButton).toHaveAttribute("href", "/signup");
+
+    await expect(page.getByText("Conceptual Soundness")).toBeVisible();
+    await expect(page.getByText("Outcomes Analysis")).toBeVisible();
+    await expect(page.getByText("Ongoing Monitoring")).toBeVisible();
+
+    await expect(
+      page.getByText("For training and synthetic model documents only")
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Hardens the CI/CD pipeline with three new stages.

### What's included
- **Playwright E2E test** — `tests/e2e/landing.spec.ts` tests landing page renders correctly (title, heading, CTAs, pillar cards, footer disclaimer). Config: chromium only, 30s timeout.
- **Gitleaks secret scanning** — pre-commit secrets detection via `gitleaks/gitleaks-action@v2` in both PR and deploy workflows.
- **AI PR review** — `.github/workflows/ai-review.yml` using `anthropics/claude-code-action@beta` to review PRs against Prova codebase conventions (TypeScript strict, Zod schemas, error handling, security).

### Pipeline stages (10 total)
1. npm audit (security)
2. ESLint
3. TypeScript type check
4. Unit + integration tests (Jest)
5. AI regression tests
6. E2E tests (Playwright)
7. Gitleaks secret scan
8. AI PR review (separate workflow)
9. Build
10. Vercel production deploy

### Files changed
- `.github/workflows/pr.yml` — added Playwright + Gitleaks steps
- `.github/workflows/deploy.yml` — same
- `.github/workflows/ai-review.yml` — new
- `playwright.config.ts` — new
- `tests/e2e/landing.spec.ts` — new
- `package.json` — added @playwright/test, test:e2e script