### PR TITLE
feat: scoped re-assessment with dispute trail

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,8 @@
+# Prova — Known Issues
+
+## Re-assessment gap-list cross-run variation
+
+Re-assessment gap lists may show minor variation across runs even with
+identical inputs, due to non-zero LLM temperature. The `dispute_resolution`
+field is the source of truth for the agent's reasoning on each disputed
+gap; the `gap_diff` is informational.

--- a/src/app/(dashboard)/submissions/[id]/compare/[reassessmentId]/page.tsx
+++ b/src/app/(dashboard)/submissions/[id]/compare/[reassessmentId]/page.tsx
@@ -1,0 +1,677 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import Card from "@/components/ui/Card";
+import Skeleton from "@/components/ui/Skeleton";
+import Toast from "@/components/ui/Toast";
+import { getScoreColor } from "@/components/dashboard/utils";
+import type { CompareResponse } from "@/lib/validation/schemas";
+
+const PILLAR_LABELS: Record<string, string> = {
+  conceptual_soundness: "Conceptual Soundness",
+  outcomes_analysis: "Outcomes Analysis",
+  ongoing_monitoring: "Ongoing Monitoring",
+};
+
+const DISPUTE_TYPE_LABELS: Record<string, string> = {
+  false_positive: "False positive",
+  wrong_severity: "Wrong severity",
+  missing_context: "Missing context",
+};
+
+const SECTION_HEADER_STYLE: React.CSSProperties = {
+  fontFamily: "var(--font-playfair)",
+  fontSize: "18px",
+  fontWeight: 600,
+  color: "var(--color-text-primary)",
+  marginBottom: "12px",
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontFamily: "var(--font-geist)",
+  fontSize: "10px",
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+  color: "var(--color-text-secondary)",
+  marginBottom: "6px",
+};
+
+const SEVERITY_COLORS: Record<string, string> = {
+  Critical: "var(--color-critical)",
+  Major: "var(--color-warning)",
+  Minor: "var(--color-text-secondary)",
+};
+
+function deltaColor(delta: number): string {
+  if (delta > 0) return "var(--color-compliant)";
+  if (delta < 0) return "var(--color-critical)";
+  return "var(--color-text-secondary)";
+}
+
+function deltaArrow(delta: number): string {
+  if (delta > 0) return "↑";
+  if (delta < 0) return "↓";
+  return "→";
+}
+
+function formatDelta(delta: number): string {
+  if (delta === 0) return "0";
+  const rounded = Math.round(delta * 10) / 10;
+  return rounded > 0 ? `+${rounded}` : `${rounded}`;
+}
+
+function CompareSkeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+      <Skeleton height={120} />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: "12px" }}>
+        {[0, 1, 2, 3].map((i) => (
+          <Skeleton key={i} height={92} />
+        ))}
+      </div>
+      <Skeleton height={200} />
+      <Skeleton height={150} />
+    </div>
+  );
+}
+
+function ScoreDeltaCard({
+  label,
+  before,
+  after,
+  delta,
+  highlighted,
+}: {
+  label: string;
+  before: number;
+  after: number;
+  delta: number;
+  highlighted?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        background: "var(--color-bg-secondary)",
+        border: highlighted
+          ? "1px solid color-mix(in srgb, var(--color-accent) 50%, transparent)"
+          : "1px solid var(--color-border)",
+        borderRadius: "2px",
+        padding: "16px",
+      }}
+    >
+      <div style={LABEL_STYLE}>{label}</div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: "8px",
+          marginTop: "6px",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-ibm-plex-mono)",
+            fontSize: "12px",
+            color: "var(--color-text-secondary)",
+            textDecoration: "line-through",
+          }}
+        >
+          {Math.round(before)}
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--font-ibm-plex-mono)",
+            fontSize: "26px",
+            fontWeight: 600,
+            color: getScoreColor(after),
+          }}
+        >
+          {Math.round(after)}
+        </span>
+      </div>
+      <div
+        style={{
+          marginTop: "6px",
+          fontFamily: "var(--font-ibm-plex-mono)",
+          fontSize: "12px",
+          fontWeight: 500,
+          color: deltaColor(delta),
+        }}
+      >
+        {deltaArrow(delta)} {formatDelta(delta)}
+      </div>
+    </div>
+  );
+}
+
+function GapRow({
+  code,
+  name,
+  severityBefore,
+  severityAfter,
+  description,
+}: {
+  code: string;
+  name: string;
+  severityBefore?: string;
+  severityAfter?: string;
+  description?: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+        padding: "10px 12px",
+        borderBottom: "1px solid var(--color-border)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <span
+          style={{
+            fontFamily: "var(--font-ibm-plex-mono)",
+            fontSize: "11px",
+            color: "var(--color-accent)",
+          }}
+        >
+          {code}
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--font-geist)",
+            fontSize: "12px",
+            color: "var(--color-text-primary)",
+          }}
+        >
+          {name}
+        </span>
+        {severityBefore && severityAfter ? (
+          <span
+            style={{
+              fontFamily: "var(--font-geist)",
+              fontSize: "11px",
+              marginLeft: "auto",
+            }}
+          >
+            <span
+              style={{
+                color: SEVERITY_COLORS[severityBefore] ?? "var(--color-text-secondary)",
+                textDecoration: "line-through",
+              }}
+            >
+              {severityBefore}
+            </span>
+            <span style={{ margin: "0 6px", color: "var(--color-text-secondary)" }}>
+              &rarr;
+            </span>
+            <span
+              style={{ color: SEVERITY_COLORS[severityAfter] ?? "var(--color-text-secondary)" }}
+            >
+              {severityAfter}
+            </span>
+          </span>
+        ) : severityAfter ? (
+          <span
+            style={{
+              fontFamily: "var(--font-geist)",
+              fontSize: "11px",
+              marginLeft: "auto",
+              color: SEVERITY_COLORS[severityAfter] ?? "var(--color-text-secondary)",
+            }}
+          >
+            {severityAfter}
+          </span>
+        ) : severityBefore ? (
+          <span
+            style={{
+              fontFamily: "var(--font-geist)",
+              fontSize: "11px",
+              marginLeft: "auto",
+              color: SEVERITY_COLORS[severityBefore] ?? "var(--color-text-secondary)",
+            }}
+          >
+            {severityBefore}
+          </span>
+        ) : null}
+      </div>
+      {description ? (
+        <div
+          style={{
+            fontFamily: "var(--font-geist)",
+            fontSize: "11px",
+            color: "var(--color-text-secondary)",
+            lineHeight: 1.5,
+          }}
+        >
+          {description}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function ComparePage() {
+  const params = useParams<{ id: string; reassessmentId: string }>();
+  const id = params.id;
+  const reassessmentId = params.reassessmentId;
+
+  const [data, setData] = useState<CompareResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: "error" } | null>(null);
+
+  useEffect(() => {
+    if (!id || !reassessmentId) return;
+
+    async function fetchCompare() {
+      setLoading(true);
+      setNotFound(false);
+      try {
+        const res = await fetch(
+          `/api/submissions/${id}/compare/${reassessmentId}`
+        );
+        if (res.status === 401) {
+          window.location.href = "/login";
+          return;
+        }
+        if (res.status === 404) {
+          setNotFound(true);
+          setLoading(false);
+          return;
+        }
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as { message?: string } | null;
+          setToast({
+            message: body?.message ?? "Failed to load comparison.",
+            type: "error",
+          });
+          setLoading(false);
+          return;
+        }
+        const body = (await res.json()) as CompareResponse;
+        setData(body);
+      } catch {
+        setToast({
+          message: "Network error. Please check your connection.",
+          type: "error",
+        });
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchCompare();
+  }, [id, reassessmentId]);
+
+  return (
+    <main
+      style={{
+        background: "var(--color-bg-primary)",
+        minHeight: "100vh",
+        padding: "32px 20px",
+      }}
+    >
+      <div style={{ maxWidth: 980, margin: "0 auto" }}>
+        <Link
+          href={`/submissions/${id}`}
+          style={{
+            fontFamily: "var(--font-geist)",
+            fontSize: "13px",
+            color: "var(--color-accent)",
+            textDecoration: "none",
+            display: "inline-block",
+            marginBottom: "24px",
+          }}
+        >
+          &larr; Back to submission
+        </Link>
+
+        {loading && <CompareSkeleton />}
+
+        {!loading && notFound && (
+          <Card animate>
+            <div style={{ textAlign: "center", padding: "48px 0" }}>
+              <div
+                style={{
+                  fontFamily: "var(--font-geist)",
+                  fontSize: "14px",
+                  color: "var(--color-text-secondary)",
+                  marginBottom: "6px",
+                }}
+              >
+                Comparison not found
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-geist)",
+                  fontSize: "12px",
+                  color: "var(--color-text-secondary)",
+                }}
+              >
+                The re-assessment may have been deleted or does not belong to this submission.
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {!loading && data && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "28px" }}>
+            <div>
+              <h1
+                style={{
+                  fontFamily: "var(--font-playfair)",
+                  fontSize: "26px",
+                  fontWeight: 700,
+                  color: "var(--color-text-primary)",
+                  margin: "0 0 6px 0",
+                }}
+              >
+                Re-assessment comparison
+              </h1>
+              <div
+                style={{
+                  fontFamily: "var(--font-geist)",
+                  fontSize: "12px",
+                  color: "var(--color-text-secondary)",
+                }}
+              >
+                {data.parent.model_name} v{data.parent.version_number} &middot; pillar
+                re-assessed: <strong>{PILLAR_LABELS[data.pillar_reassessed]}</strong>
+              </div>
+            </div>
+
+            {data.reassessment.low_confidence_manual_review && (
+              <div
+                style={{
+                  background:
+                    "color-mix(in srgb, var(--color-warning) 10%, var(--color-bg-secondary))",
+                  border:
+                    "1px solid color-mix(in srgb, var(--color-warning) 30%, transparent)",
+                  borderRadius: "2px",
+                  padding: "14px 18px",
+                  fontFamily: "var(--font-geist)",
+                  fontSize: "13px",
+                  color: "var(--color-warning)",
+                  lineHeight: 1.5,
+                }}
+              >
+                Re-assessment finished below the 0.7 confidence threshold &mdash; flagged
+                for manual review.
+              </div>
+            )}
+
+            {/* Score deltas */}
+            <div>
+              <div style={SECTION_HEADER_STYLE}>Score deltas</div>
+              <div
+                className="grid grid-cols-1 md:grid-cols-4 gap-3"
+                style={{ display: "grid", gap: "12px" }}
+              >
+                <ScoreDeltaCard
+                  label="Final score"
+                  before={data.parent.final_score}
+                  after={data.reassessment.final_score}
+                  delta={data.pillar_score_deltas.final_score}
+                  highlighted
+                />
+                <ScoreDeltaCard
+                  label="Conceptual"
+                  before={data.parent.conceptual_score}
+                  after={data.reassessment.conceptual_score}
+                  delta={data.pillar_score_deltas.conceptual_soundness}
+                  highlighted={data.pillar_reassessed === "conceptual_soundness"}
+                />
+                <ScoreDeltaCard
+                  label="Outcomes"
+                  before={data.parent.outcomes_score}
+                  after={data.reassessment.outcomes_score}
+                  delta={data.pillar_score_deltas.outcomes_analysis}
+                  highlighted={data.pillar_reassessed === "outcomes_analysis"}
+                />
+                <ScoreDeltaCard
+                  label="Monitoring"
+                  before={data.parent.monitoring_score}
+                  after={data.reassessment.monitoring_score}
+                  delta={data.pillar_score_deltas.ongoing_monitoring}
+                  highlighted={data.pillar_reassessed === "ongoing_monitoring"}
+                />
+              </div>
+            </div>
+
+            {/* Dispute events */}
+            <div>
+              <div style={SECTION_HEADER_STYLE}>Dispute(s) that triggered this re-run</div>
+              {data.dispute_events.length === 0 ? (
+                <div
+                  style={{
+                    background: "var(--color-bg-secondary)",
+                    border: "1px solid var(--color-border)",
+                    padding: "16px",
+                    fontFamily: "var(--font-geist)",
+                    fontSize: "12px",
+                    color: "var(--color-text-secondary)",
+                  }}
+                >
+                  No dispute records found.
+                </div>
+              ) : (
+                <div
+                  style={{
+                    background: "var(--color-bg-secondary)",
+                    border: "1px solid var(--color-border)",
+                  }}
+                >
+                  {data.dispute_events.map((d) => (
+                    <div
+                      key={d.id}
+                      style={{
+                        padding: "14px 16px",
+                        borderBottom: "1px solid var(--color-border)",
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "6px",
+                      }}
+                    >
+                      <div
+                        style={{
+                          fontFamily: "var(--font-geist)",
+                          fontSize: "11px",
+                          color: "var(--color-text-secondary)",
+                          letterSpacing: "0.06em",
+                          textTransform: "uppercase",
+                        }}
+                      >
+                        {DISPUTE_TYPE_LABELS[d.dispute_type] ?? d.dispute_type}
+                      </div>
+                      <div
+                        style={{
+                          fontFamily: "var(--font-geist)",
+                          fontSize: "13px",
+                          color: "var(--color-text-primary)",
+                          lineHeight: 1.5,
+                        }}
+                      >
+                        {d.reviewer_rationale}
+                      </div>
+                      {d.proposed_resolution ? (
+                        <div
+                          style={{
+                            fontFamily: "var(--font-geist)",
+                            fontSize: "12px",
+                            color: "var(--color-text-secondary)",
+                            lineHeight: 1.5,
+                            paddingTop: "4px",
+                            borderTop: "1px dashed var(--color-border)",
+                            marginTop: "4px",
+                          }}
+                        >
+                          <span style={{ color: "var(--color-text-secondary)" }}>
+                            Proposed resolution:{" "}
+                          </span>
+                          {d.proposed_resolution}
+                        </div>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Gap diff */}
+            <div>
+              <div style={SECTION_HEADER_STYLE}>Gap diff</div>
+              <div
+                style={{ display: "grid", gridTemplateColumns: "1fr", gap: "16px" }}
+              >
+                <div>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-geist)",
+                      fontSize: "11px",
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      color: "var(--color-compliant)",
+                      marginBottom: "6px",
+                    }}
+                  >
+                    Removed ({data.gap_diff.removed.length})
+                  </div>
+                  <div
+                    style={{
+                      background: "var(--color-bg-secondary)",
+                      border: "1px solid var(--color-border)",
+                    }}
+                  >
+                    {data.gap_diff.removed.length === 0 ? (
+                      <div
+                        style={{
+                          padding: "12px",
+                          fontFamily: "var(--font-geist)",
+                          fontSize: "12px",
+                          color: "var(--color-text-secondary)",
+                        }}
+                      >
+                        No gaps removed.
+                      </div>
+                    ) : (
+                      data.gap_diff.removed.map((g) => (
+                        <GapRow
+                          key={`r-${g.id}`}
+                          code={g.element_code}
+                          name={g.element_name}
+                          severityBefore={g.severity}
+                          description={g.description}
+                        />
+                      ))
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-geist)",
+                      fontSize: "11px",
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      color: "var(--color-critical)",
+                      marginBottom: "6px",
+                    }}
+                  >
+                    Added ({data.gap_diff.added.length})
+                  </div>
+                  <div
+                    style={{
+                      background: "var(--color-bg-secondary)",
+                      border: "1px solid var(--color-border)",
+                    }}
+                  >
+                    {data.gap_diff.added.length === 0 ? (
+                      <div
+                        style={{
+                          padding: "12px",
+                          fontFamily: "var(--font-geist)",
+                          fontSize: "12px",
+                          color: "var(--color-text-secondary)",
+                        }}
+                      >
+                        No gaps added.
+                      </div>
+                    ) : (
+                      data.gap_diff.added.map((g) => (
+                        <GapRow
+                          key={`a-${g.id}`}
+                          code={g.element_code}
+                          name={g.element_name}
+                          severityAfter={g.severity}
+                          description={g.description}
+                        />
+                      ))
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-geist)",
+                      fontSize: "11px",
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      color: "var(--color-warning)",
+                      marginBottom: "6px",
+                    }}
+                  >
+                    Severity changed ({data.gap_diff.severity_changed.length})
+                  </div>
+                  <div
+                    style={{
+                      background: "var(--color-bg-secondary)",
+                      border: "1px solid var(--color-border)",
+                    }}
+                  >
+                    {data.gap_diff.severity_changed.length === 0 ? (
+                      <div
+                        style={{
+                          padding: "12px",
+                          fontFamily: "var(--font-geist)",
+                          fontSize: "12px",
+                          color: "var(--color-text-secondary)",
+                        }}
+                      >
+                        No severity changes.
+                      </div>
+                    ) : (
+                      data.gap_diff.severity_changed.map((s) => (
+                        <GapRow
+                          key={`s-${s.element_code}`}
+                          code={s.element_code}
+                          name={s.element_name}
+                          severityBefore={s.before}
+                          severityAfter={s.after}
+                        />
+                      ))
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {toast && (
+          <Toast
+            message={toast.message}
+            type={toast.type}
+            visible={!!toast}
+            onClose={() => setToast(null)}
+            duration={5000}
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/(dashboard)/submissions/[id]/compare/[reassessmentId]/page.tsx
+++ b/src/app/(dashboard)/submissions/[id]/compare/[reassessmentId]/page.tsx
@@ -21,6 +21,23 @@ const DISPUTE_TYPE_LABELS: Record<string, string> = {
   missing_context: "Missing context",
 };
 
+const RESOLUTION_LABELS: Record<string, string> = {
+  reversed_with_evidence: "Reversed: reviewer evidence accepted",
+  severity_adjusted_with_evidence:
+    "Severity adjusted: reviewer evidence accepted",
+  retained_insufficient_evidence:
+    "Retained: reviewer rationale lacked specific document evidence",
+  retained_evidence_supports_original:
+    "Retained: document evidence supports original finding",
+};
+
+const RESOLUTION_COLORS: Record<string, string> = {
+  reversed_with_evidence: "var(--color-compliant)",
+  severity_adjusted_with_evidence: "var(--color-warning)",
+  retained_insufficient_evidence: "var(--color-critical)",
+  retained_evidence_supports_original: "var(--color-text-secondary)",
+};
+
 const SECTION_HEADER_STYLE: React.CSSProperties = {
   fontFamily: "var(--font-playfair)",
   fontSize: "18px",
@@ -464,58 +481,148 @@ export default function ComparePage() {
                     border: "1px solid var(--color-border)",
                   }}
                 >
-                  {data.dispute_events.map((d) => (
-                    <div
-                      key={d.id}
-                      style={{
-                        padding: "14px 16px",
-                        borderBottom: "1px solid var(--color-border)",
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: "6px",
-                      }}
-                    >
+                  {data.dispute_events.map((d) => {
+                    const parentGap = data.parent.gap_analysis.find(
+                      (g) => g.id === d.gap_id
+                    );
+                    const resolution = parentGap
+                      ? data.dispute_resolutions.find(
+                          (r) => r.element_code === parentGap.element_code
+                        )
+                      : undefined;
+                    const resolutionLabel = resolution
+                      ? RESOLUTION_LABELS[resolution.resolution]
+                      : null;
+                    const resolutionColor = resolution
+                      ? RESOLUTION_COLORS[resolution.resolution] ??
+                        "var(--color-text-secondary)"
+                      : "var(--color-text-secondary)";
+                    return (
                       <div
+                        key={d.id}
                         style={{
-                          fontFamily: "var(--font-geist)",
-                          fontSize: "11px",
-                          color: "var(--color-text-secondary)",
-                          letterSpacing: "0.06em",
-                          textTransform: "uppercase",
+                          padding: "14px 16px",
+                          borderBottom: "1px solid var(--color-border)",
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "6px",
                         }}
                       >
-                        {DISPUTE_TYPE_LABELS[d.dispute_type] ?? d.dispute_type}
-                      </div>
-                      <div
-                        style={{
-                          fontFamily: "var(--font-geist)",
-                          fontSize: "13px",
-                          color: "var(--color-text-primary)",
-                          lineHeight: 1.5,
-                        }}
-                      >
-                        {d.reviewer_rationale}
-                      </div>
-                      {d.proposed_resolution ? (
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "10px",
+                            flexWrap: "wrap",
+                          }}
+                        >
+                          <span
+                            style={{
+                              fontFamily: "var(--font-geist)",
+                              fontSize: "11px",
+                              color: "var(--color-text-secondary)",
+                              letterSpacing: "0.06em",
+                              textTransform: "uppercase",
+                            }}
+                          >
+                            {DISPUTE_TYPE_LABELS[d.dispute_type] ?? d.dispute_type}
+                          </span>
+                          {parentGap ? (
+                            <span
+                              style={{
+                                fontFamily: "var(--font-ibm-plex-mono)",
+                                fontSize: "11px",
+                                color: "var(--color-accent)",
+                              }}
+                            >
+                              {parentGap.element_code}
+                            </span>
+                          ) : null}
+                        </div>
                         <div
                           style={{
                             fontFamily: "var(--font-geist)",
-                            fontSize: "12px",
-                            color: "var(--color-text-secondary)",
+                            fontSize: "13px",
+                            color: "var(--color-text-primary)",
                             lineHeight: 1.5,
-                            paddingTop: "4px",
-                            borderTop: "1px dashed var(--color-border)",
-                            marginTop: "4px",
                           }}
                         >
-                          <span style={{ color: "var(--color-text-secondary)" }}>
-                            Proposed resolution:{" "}
-                          </span>
-                          {d.proposed_resolution}
+                          {d.reviewer_rationale}
                         </div>
-                      ) : null}
-                    </div>
-                  ))}
+                        {d.proposed_resolution ? (
+                          <div
+                            style={{
+                              fontFamily: "var(--font-geist)",
+                              fontSize: "12px",
+                              color: "var(--color-text-secondary)",
+                              lineHeight: 1.5,
+                            }}
+                          >
+                            <span style={{ color: "var(--color-text-secondary)" }}>
+                              Proposed resolution:{" "}
+                            </span>
+                            {d.proposed_resolution}
+                          </div>
+                        ) : null}
+                        {resolutionLabel ? (
+                          <div
+                            style={{
+                              marginTop: "4px",
+                              paddingTop: "8px",
+                              borderTop: "1px dashed var(--color-border)",
+                              display: "flex",
+                              flexDirection: "column",
+                              gap: "4px",
+                            }}
+                          >
+                            <div
+                              style={{
+                                display: "inline-flex",
+                                alignItems: "center",
+                                gap: "8px",
+                              }}
+                            >
+                              <span
+                                style={{
+                                  display: "block",
+                                  width: "8px",
+                                  height: "8px",
+                                  borderRadius: "50%",
+                                  background: resolutionColor,
+                                  flexShrink: 0,
+                                }}
+                              />
+                              <span
+                                style={{
+                                  fontFamily: "var(--font-geist)",
+                                  fontSize: "12px",
+                                  fontWeight: 500,
+                                  color: resolutionColor,
+                                  lineHeight: 1.4,
+                                }}
+                              >
+                                {resolutionLabel}
+                              </span>
+                            </div>
+                            {resolution?.note ? (
+                              <div
+                                style={{
+                                  fontFamily: "var(--font-geist)",
+                                  fontSize: "11px",
+                                  fontStyle: "italic",
+                                  color: "var(--color-text-secondary)",
+                                  lineHeight: 1.5,
+                                  paddingLeft: "16px",
+                                }}
+                              >
+                                {resolution.note}
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/src/app/(dashboard)/submissions/[id]/page.tsx
+++ b/src/app/(dashboard)/submissions/[id]/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import type { SubmissionDetail, Gap } from "@/lib/validation/schemas";
+import type {
+  GapWithId,
+  ReassessmentResponse,
+  SubmissionDetail,
+} from "@/lib/validation/schemas";
 import Badge from "@/components/ui/Badge";
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
@@ -14,11 +18,12 @@ import { getScoreColor } from "@/components/dashboard/utils";
 import type { Status } from "@/components/dashboard/utils";
 import PillarScoreCard from "@/components/compliance/PillarScoreCard";
 import GapAnalysisTable from "@/components/compliance/GapAnalysisTable";
+import DisputeModal from "@/components/compliance/DisputeModal";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function countGapsBySeverity(
-  gaps: Gap[],
+  gaps: GapWithId[],
   prefix: "CS" | "OA" | "OM"
 ): { critical: number; major: number; minor: number } {
   const pillarGaps = gaps.filter((g) => g.element_code.startsWith(prefix));
@@ -176,6 +181,7 @@ function DetailLoadingSkeleton() {
 
 export default function SubmissionDetailPage() {
   const params = useParams<{ id: string }>();
+  const router = useRouter();
   const id = params.id;
 
   const [submission, setSubmission] = useState<SubmissionDetail | null>(null);
@@ -186,6 +192,7 @@ export default function SubmissionDetailPage() {
     type: "error";
   } | null>(null);
   const [downloadLoading, setDownloadLoading] = useState(false);
+  const [disputeGap, setDisputeGap] = useState<GapWithId | null>(null);
 
   const handleDownloadReport = async () => {
     setDownloadLoading(true);
@@ -567,7 +574,10 @@ export default function SubmissionDetailPage() {
               >
                 Gap Analysis
               </div>
-              <GapAnalysisTable gaps={submission.gap_analysis} />
+              <GapAnalysisTable
+                gaps={submission.gap_analysis}
+                onDispute={(g) => setDisputeGap(g)}
+              />
             </div>
 
             {/* Action buttons */}
@@ -596,6 +606,18 @@ export default function SubmissionDetailPage() {
             duration={5000}
           />
         )}
+
+        {/* Dispute modal */}
+        <DisputeModal
+          open={!!disputeGap}
+          onClose={() => setDisputeGap(null)}
+          assessmentId={id ?? ""}
+          gap={disputeGap}
+          onSuccess={(res: ReassessmentResponse) => {
+            setDisputeGap(null);
+            router.push(`/submissions/${id}/compare/${res.reassessment_id}`);
+          }}
+        />
       </div>
     </main>
   );

--- a/src/app/api/disputes/route.ts
+++ b/src/app/api/disputes/route.ts
@@ -1,0 +1,294 @@
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import { createServerClient, createServiceClient } from '@/lib/supabase/server';
+import { errorResponse } from '@/lib/errors/messages';
+import {
+  DisputeRequestSchema,
+  type DisputeRequest,
+  type Gap,
+  type AgentOutput,
+} from '@/lib/validation/schemas';
+import {
+  pillarFromElementCode,
+  runScopedReassessment,
+  type Pillar,
+} from '@/lib/agents/scopedReassessment';
+import { calculateScores } from '@/lib/scoring/calculator';
+import { AgentParseError, AgentSchemaError } from '@/lib/agents/errors';
+
+function gapsForPillar(gaps: Gap[], pillar: Pillar): Gap[] {
+  const prefix =
+    pillar === 'conceptual_soundness'
+      ? 'CS-'
+      : pillar === 'outcomes_analysis'
+        ? 'OA-'
+        : 'OM-';
+  return gaps.filter((g) => g.element_code.startsWith(prefix));
+}
+
+function buildPriorAgentOutput(
+  pillar: Pillar,
+  score: number,
+  gaps: Gap[]
+): AgentOutput {
+  return {
+    pillar,
+    score,
+    confidence: 0.8,
+    gaps,
+    summary:
+      'Reused from prior assessment — this pillar was not re-run during the scoped re-assessment.',
+  };
+}
+
+export async function POST(request: Request) {
+  // 1. Verify session
+  let supabase;
+  try {
+    supabase = await createServerClient();
+  } catch (err) {
+    Sentry.captureException(err);
+    return errorResponse('UNKNOWN_ERROR');
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return errorResponse('AUTH_REQUIRED');
+  }
+
+  const userId = user.id;
+
+  // 2. Validate request body
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('VALIDATION_ERROR', { message: 'Request body must be valid JSON.' });
+  }
+
+  const parsed = DisputeRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return errorResponse('VALIDATION_ERROR', {
+      message: parsed.error.issues[0]?.message ?? 'Invalid dispute request.',
+    });
+  }
+  const dispute: DisputeRequest = parsed.data;
+
+  // 3. Fetch parent submission and verify ownership (RLS also enforces this)
+  const { data: parentSub, error: parentErr } = await supabase
+    .from('submissions')
+    .select(
+      'id, user_id, model_id, version_number, document_text, conceptual_score, outcomes_score, monitoring_score, gap_analysis, models(model_name)'
+    )
+    .eq('id', dispute.assessment_id)
+    .maybeSingle();
+
+  if (parentErr) {
+    Sentry.captureException(parentErr);
+    return errorResponse('DATABASE_ERROR');
+  }
+  if (!parentSub || parentSub.user_id !== userId) {
+    return errorResponse('SUBMISSION_NOT_FOUND');
+  }
+
+  // 4. Fetch the disputed gap row to determine pillar + verify it belongs here
+  const { data: gapRow, error: gapErr } = await supabase
+    .from('gaps')
+    .select('id, submission_id, user_id, element_code, element_name, severity, description, recommendation, pillar')
+    .eq('id', dispute.gap_id)
+    .maybeSingle();
+
+  if (gapErr) {
+    Sentry.captureException(gapErr);
+    return errorResponse('DATABASE_ERROR');
+  }
+  if (
+    !gapRow ||
+    gapRow.user_id !== userId ||
+    gapRow.submission_id !== parentSub.id
+  ) {
+    return errorResponse('VALIDATION_ERROR', {
+      message: 'Disputed gap does not belong to the referenced assessment.',
+    });
+  }
+
+  const pillar = pillarFromElementCode(gapRow.element_code);
+
+  // 5. Persist the dispute event (append-only trail) BEFORE re-running. If the
+  // re-run fails we still keep the dispute filed for audit — the user can retry.
+  const db = createServiceClient();
+
+  const { data: disputeEvent, error: disputeErr } = await db
+    .from('dispute_events')
+    .insert({
+      assessment_id: parentSub.id,
+      gap_id: gapRow.id,
+      user_id: userId,
+      dispute_type: dispute.dispute_type,
+      reviewer_rationale: dispute.reviewer_rationale,
+      proposed_resolution: dispute.proposed_resolution ?? null,
+    })
+    .select('id, created_at')
+    .single();
+
+  if (disputeErr || !disputeEvent) {
+    Sentry.captureException(disputeErr ?? new Error('Failed to insert dispute event'));
+    return errorResponse('DATABASE_ERROR');
+  }
+
+  // 6. Build prior pillar outputs from the stored gap_analysis. The two
+  // un-disputed pillars are reused unchanged; the disputed pillar is re-run.
+  const allPriorGaps = (parentSub.gap_analysis ?? []) as Gap[];
+  const csGaps = gapsForPillar(allPriorGaps, 'conceptual_soundness');
+  const oaGaps = gapsForPillar(allPriorGaps, 'outcomes_analysis');
+  const omGaps = gapsForPillar(allPriorGaps, 'ongoing_monitoring');
+
+  const priorCs = buildPriorAgentOutput(
+    'conceptual_soundness',
+    Number(parentSub.conceptual_score),
+    csGaps
+  );
+  const priorOa = buildPriorAgentOutput(
+    'outcomes_analysis',
+    Number(parentSub.outcomes_score),
+    oaGaps
+  );
+  const priorOm = buildPriorAgentOutput(
+    'ongoing_monitoring',
+    Number(parentSub.monitoring_score),
+    omGaps
+  );
+
+  const modelsRel = parentSub.models as unknown as { model_name: string } | null;
+  const modelName = modelsRel?.model_name ?? 'Unknown';
+
+  // 7. Run scoped re-assessment (single pillar agent + judge, threshold 0.7)
+  let result;
+  try {
+    result = await runScopedReassessment({
+      documentText: parentSub.document_text,
+      modelName,
+      pillar,
+      previousCsOutput: priorCs,
+      previousOaOutput: priorOa,
+      previousOmOutput: priorOm,
+      disputes: [
+        {
+          element_code: gapRow.element_code,
+          dispute_type: dispute.dispute_type,
+          reviewer_rationale: dispute.reviewer_rationale,
+          proposed_resolution: dispute.proposed_resolution,
+        },
+      ],
+    });
+  } catch (err) {
+    if (err instanceof AgentParseError || err instanceof AgentSchemaError) {
+      Sentry.captureException(err);
+      return errorResponse('AI_SCHEMA_INVALID');
+    }
+    Sentry.captureException(err);
+    return errorResponse('AI_UNAVAILABLE');
+  }
+
+  // 8. Recalculate scores using the canonical formula
+  const scoring = calculateScores(result.csOutput, result.oaOutput, result.omOutput);
+
+  // 9. Persist the new submission row, linked via parent_assessment_id.
+  // Re-assessments share their parent's version_number (the partial unique index
+  // added in the migration only enforces uniqueness for parent_assessment_id IS NULL).
+  const newAllGaps: Gap[] = [
+    ...result.csOutput.gaps,
+    ...result.oaOutput.gaps,
+    ...result.omOutput.gaps,
+  ];
+
+  const { data: newSub, error: insertErr } = await db
+    .from('submissions')
+    .insert({
+      model_id: parentSub.model_id,
+      user_id: userId,
+      version_number: parentSub.version_number,
+      parent_assessment_id: parentSub.id,
+      document_text: parentSub.document_text,
+      conceptual_score: scoring.pillar_scores.conceptual_soundness,
+      outcomes_score: scoring.pillar_scores.outcomes_analysis,
+      monitoring_score: scoring.pillar_scores.ongoing_monitoring,
+      final_score: scoring.final_score,
+      gap_analysis: newAllGaps,
+      judge_confidence: result.judgeOutput.confidence,
+      assessment_confidence_label: result.judgeOutput.confidence_label,
+      retry_count: result.retryCount,
+      low_confidence_manual_review: result.lowConfidenceManualReview,
+    })
+    .select('id, created_at')
+    .single();
+
+  if (insertErr || !newSub) {
+    Sentry.captureException(insertErr ?? new Error('Failed to insert reassessment submission'));
+    return errorResponse('DATABASE_ERROR');
+  }
+
+  const reassessmentId = String((newSub as { id: string }).id);
+
+  // 10. Persist gaps for the new submission row
+  const newGapRows = [
+    ...result.csOutput.gaps.map((g) => ({
+      submission_id: reassessmentId,
+      user_id: userId,
+      pillar: 'conceptual_soundness' as const,
+      element_code: g.element_code,
+      element_name: g.element_name,
+      severity: g.severity,
+      description: g.description,
+      recommendation: g.recommendation,
+    })),
+    ...result.oaOutput.gaps.map((g) => ({
+      submission_id: reassessmentId,
+      user_id: userId,
+      pillar: 'outcomes_analysis' as const,
+      element_code: g.element_code,
+      element_name: g.element_name,
+      severity: g.severity,
+      description: g.description,
+      recommendation: g.recommendation,
+    })),
+    ...result.omOutput.gaps.map((g) => ({
+      submission_id: reassessmentId,
+      user_id: userId,
+      pillar: 'ongoing_monitoring' as const,
+      element_code: g.element_code,
+      element_name: g.element_name,
+      severity: g.severity,
+      description: g.description,
+      recommendation: g.recommendation,
+    })),
+  ];
+
+  if (newGapRows.length > 0) {
+    const { error: gapsInsertErr } = await db.from('gaps').insert(newGapRows);
+    if (gapsInsertErr) {
+      Sentry.captureException(gapsInsertErr);
+      // Compensating delete to avoid orphan submission row
+      await db.from('submissions').delete().eq('id', reassessmentId);
+      return errorResponse('DATABASE_ERROR');
+    }
+  }
+
+  return NextResponse.json(
+    {
+      reassessment_id: reassessmentId,
+      parent_assessment_id: parentSub.id,
+      pillar_reassessed: pillar,
+      scoring,
+      judge_confidence: result.judgeOutput.confidence,
+      judge_confidence_label: result.judgeOutput.confidence_label,
+      low_confidence_manual_review: result.lowConfidenceManualReview,
+      dispute_event_id: (disputeEvent as { id: string }).id,
+      created_at: String((newSub as { created_at: string }).created_at),
+    },
+    { status: 200 }
+  );
+}

--- a/src/app/api/disputes/route.ts
+++ b/src/app/api/disputes/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { createServerClient, createServiceClient } from '@/lib/supabase/server';
@@ -5,6 +6,7 @@ import { errorResponse } from '@/lib/errors/messages';
 import {
   DisputeRequestSchema,
   type DisputeRequest,
+  type DisputeResolutionItem,
   type Gap,
   type AgentOutput,
 } from '@/lib/validation/schemas';
@@ -15,6 +17,19 @@ import {
 } from '@/lib/agents/scopedReassessment';
 import { calculateScores } from '@/lib/scoring/calculator';
 import { AgentParseError, AgentSchemaError } from '@/lib/agents/errors';
+
+const MODEL_USED = 'claude-haiku-4-5-20251001';
+
+function disputedPillarOutput(
+  pillar: Pillar,
+  cs: AgentOutput,
+  oa: AgentOutput,
+  om: AgentOutput
+): AgentOutput {
+  if (pillar === 'conceptual_soundness') return cs;
+  if (pillar === 'outcomes_analysis') return oa;
+  return om;
+}
 
 function isUniqueViolation(err: { code?: string } | null | undefined): boolean {
   return err?.code === '23505';
@@ -46,6 +61,8 @@ function buildPriorAgentOutput(
 }
 
 export async function POST(request: Request) {
+  const requestStartTime = Date.now();
+
   // 1. Verify session
   let supabase;
   try {
@@ -331,6 +348,34 @@ export async function POST(request: Request) {
     }
   }
 
+  // 11. Persist eval row so the disputed pillar's dispute_resolutions are
+  // recoverable for the compare view (evals.agent_outputs is JSONB).
+  const inputTextHash = createHash('sha256').update(parentSub.document_text).digest('hex');
+  const { error: evalError } = await db.from('evals').insert({
+    submission_id: reassessmentId,
+    input_text_hash: inputTextHash,
+    agent_outputs: { cs: result.csOutput, oa: result.oaOutput, om: result.omOutput },
+    judge_output: result.judgeOutput,
+    retry_count: result.retryCount,
+    total_latency_ms: Date.now() - requestStartTime,
+    model_used: MODEL_USED,
+  });
+
+  if (evalError) {
+    // Non-fatal: dispute_resolutions won't surface in the compare view, but
+    // the re-assessment itself succeeded.
+    console.error('[disputes] evals insert failed (non-fatal):', evalError);
+    Sentry.captureException(evalError);
+  }
+
+  const disputedAgent = disputedPillarOutput(
+    pillar,
+    result.csOutput,
+    result.oaOutput,
+    result.omOutput
+  );
+  const disputeResolutions: DisputeResolutionItem[] = disputedAgent.dispute_resolutions ?? [];
+
   return NextResponse.json(
     {
       reassessment_id: reassessmentId,
@@ -341,6 +386,7 @@ export async function POST(request: Request) {
       judge_confidence_label: result.judgeOutput.confidence_label,
       low_confidence_manual_review: result.lowConfidenceManualReview,
       dispute_event_id: (disputeEvent as { id: string }).id,
+      dispute_resolutions: disputeResolutions,
       created_at: String(newSub.created_at),
     },
     { status: 200 }

--- a/src/app/api/disputes/route.ts
+++ b/src/app/api/disputes/route.ts
@@ -16,6 +16,10 @@ import {
 import { calculateScores } from '@/lib/scoring/calculator';
 import { AgentParseError, AgentSchemaError } from '@/lib/agents/errors';
 
+function isUniqueViolation(err: { code?: string } | null | undefined): boolean {
+  return err?.code === '23505';
+}
+
 function gapsForPillar(gaps: Gap[], pillar: Pillar): Gap[] {
   const prefix =
     pillar === 'conceptual_soundness'
@@ -87,6 +91,7 @@ export async function POST(request: Request) {
     .maybeSingle();
 
   if (parentErr) {
+    console.error('[disputes] parent submission lookup failed:', parentErr);
     Sentry.captureException(parentErr);
     return errorResponse('DATABASE_ERROR');
   }
@@ -102,6 +107,7 @@ export async function POST(request: Request) {
     .maybeSingle();
 
   if (gapErr) {
+    console.error('[disputes] gap lookup failed:', gapErr);
     Sentry.captureException(gapErr);
     return errorResponse('DATABASE_ERROR');
   }
@@ -135,6 +141,7 @@ export async function POST(request: Request) {
     .single();
 
   if (disputeErr || !disputeEvent) {
+    console.error('[disputes] dispute_events insert failed:', disputeErr);
     Sentry.captureException(disputeErr ?? new Error('Failed to insert dispute event'));
     return errorResponse('DATABASE_ERROR');
   }
@@ -197,41 +204,87 @@ export async function POST(request: Request) {
   const scoring = calculateScores(result.csOutput, result.oaOutput, result.omOutput);
 
   // 9. Persist the new submission row, linked via parent_assessment_id.
-  // Re-assessments share their parent's version_number (the partial unique index
-  // added in the migration only enforces uniqueness for parent_assessment_id IS NULL).
+  // Re-assessments preferably share their parent's version_number — the partial
+  // unique index added in the migration only enforces uniqueness for
+  // parent_assessment_id IS NULL. If that index isn't in place (e.g. migration
+  // not fully applied) we fall back to the next available version_number so the
+  // feature still works.
   const newAllGaps: Gap[] = [
     ...result.csOutput.gaps,
     ...result.oaOutput.gaps,
     ...result.omOutput.gaps,
   ];
 
-  const { data: newSub, error: insertErr } = await db
-    .from('submissions')
-    .insert({
-      model_id: parentSub.model_id,
-      user_id: userId,
-      version_number: parentSub.version_number,
-      parent_assessment_id: parentSub.id,
-      document_text: parentSub.document_text,
-      conceptual_score: scoring.pillar_scores.conceptual_soundness,
-      outcomes_score: scoring.pillar_scores.outcomes_analysis,
-      monitoring_score: scoring.pillar_scores.ongoing_monitoring,
-      final_score: scoring.final_score,
-      gap_analysis: newAllGaps,
-      judge_confidence: result.judgeOutput.confidence,
-      assessment_confidence_label: result.judgeOutput.confidence_label,
-      retry_count: result.retryCount,
-      low_confidence_manual_review: result.lowConfidenceManualReview,
-    })
-    .select('id, created_at')
-    .single();
+  const baseInsert = {
+    model_id: parentSub.model_id,
+    user_id: userId,
+    parent_assessment_id: parentSub.id,
+    document_text: parentSub.document_text,
+    conceptual_score: scoring.pillar_scores.conceptual_soundness,
+    outcomes_score: scoring.pillar_scores.outcomes_analysis,
+    monitoring_score: scoring.pillar_scores.ongoing_monitoring,
+    final_score: scoring.final_score,
+    gap_analysis: newAllGaps,
+    judge_confidence: result.judgeOutput.confidence,
+    assessment_confidence_label: result.judgeOutput.confidence_label,
+    retry_count: result.retryCount,
+    low_confidence_manual_review: result.lowConfidenceManualReview,
+  };
 
-  if (insertErr || !newSub) {
-    Sentry.captureException(insertErr ?? new Error('Failed to insert reassessment submission'));
-    return errorResponse('DATABASE_ERROR');
+  let newSub: { id: string; created_at: string } | null = null;
+  let lastInsertErr: unknown = null;
+
+  // First attempt: share parent's version_number
+  {
+    const { data, error } = await db
+      .from('submissions')
+      .insert({ ...baseInsert, version_number: parentSub.version_number })
+      .select('id, created_at')
+      .single();
+
+    if (!error && data) {
+      newSub = data as { id: string; created_at: string };
+    } else if (error && !isUniqueViolation(error)) {
+      console.error('[disputes] submissions insert failed (parent version):', error);
+      lastInsertErr = error;
+    } else if (error) {
+      lastInsertErr = error;
+    }
   }
 
-  const reassessmentId = String((newSub as { id: string }).id);
+  // Fallback: next available version_number (covers the case where the partial
+  // unique index didn't get applied during migration)
+  if (!newSub) {
+    const { count, error: countError } = await db
+      .from('submissions')
+      .select('id', { count: 'exact', head: true })
+      .eq('model_id', parentSub.model_id)
+      .eq('user_id', userId);
+
+    if (countError) {
+      console.error('[disputes] version count lookup failed:', countError);
+      Sentry.captureException(countError);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    const nextVersion = (count ?? 0) + 1;
+
+    const { data, error } = await db
+      .from('submissions')
+      .insert({ ...baseInsert, version_number: nextVersion })
+      .select('id, created_at')
+      .single();
+
+    if (error || !data) {
+      console.error('[disputes] submissions insert failed (fallback version):', error ?? lastInsertErr);
+      Sentry.captureException(error ?? lastInsertErr ?? new Error('Failed to insert reassessment submission'));
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    newSub = data as { id: string; created_at: string };
+  }
+
+  const reassessmentId = String(newSub.id);
 
   // 10. Persist gaps for the new submission row
   const newGapRows = [
@@ -270,6 +323,7 @@ export async function POST(request: Request) {
   if (newGapRows.length > 0) {
     const { error: gapsInsertErr } = await db.from('gaps').insert(newGapRows);
     if (gapsInsertErr) {
+      console.error('[disputes] gaps insert failed:', gapsInsertErr);
       Sentry.captureException(gapsInsertErr);
       // Compensating delete to avoid orphan submission row
       await db.from('submissions').delete().eq('id', reassessmentId);
@@ -287,7 +341,7 @@ export async function POST(request: Request) {
       judge_confidence_label: result.judgeOutput.confidence_label,
       low_confidence_manual_review: result.lowConfidenceManualReview,
       dispute_event_id: (disputeEvent as { id: string }).id,
-      created_at: String((newSub as { created_at: string }).created_at),
+      created_at: String(newSub.created_at),
     },
     { status: 200 }
   );

--- a/src/app/api/disputes/route.ts
+++ b/src/app/api/disputes/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/validation/schemas';
 import {
   pillarFromElementCode,
+  reconcileDisputeResolutions,
   runScopedReassessment,
   type Pillar,
 } from '@/lib/agents/scopedReassessment';
@@ -217,8 +218,43 @@ export async function POST(request: Request) {
     return errorResponse('AI_UNAVAILABLE');
   }
 
-  // 8. Recalculate scores using the canonical formula
-  const scoring = calculateScores(result.csOutput, result.oaOutput, result.omOutput);
+  // 8a. Reconcile the disputed pillar's gaps array against the agent's stated
+  // dispute_resolutions. The LLM is not always self-consistent — the gaps array
+  // can silently drift from what the agent declared in dispute_resolutions
+  // (e.g. declaring "retained_insufficient_evidence" while still removing the
+  // gap). For an SR 11-7 audit trail we force the persisted gaps to match the
+  // agent's stated intent. Any reconciliation warnings are logged.
+  const parentPillarGaps =
+    pillar === 'conceptual_soundness'
+      ? csGaps
+      : pillar === 'outcomes_analysis'
+        ? oaGaps
+        : omGaps;
+
+  const disputedAgentRaw =
+    pillar === 'conceptual_soundness'
+      ? result.csOutput
+      : pillar === 'outcomes_analysis'
+        ? result.oaOutput
+        : result.omOutput;
+
+  const { reconciled: reconciledDisputedAgent, warnings: reconciliationWarnings } =
+    reconcileDisputeResolutions({
+      agentOutput: disputedAgentRaw,
+      parentPillarGaps,
+      disputedElementCodes: [gapRow.element_code],
+    });
+
+  if (reconciliationWarnings.length > 0) {
+    console.warn('[disputes] reconciliation:', reconciliationWarnings.join(' | '));
+  }
+
+  const finalCs = pillar === 'conceptual_soundness' ? reconciledDisputedAgent : result.csOutput;
+  const finalOa = pillar === 'outcomes_analysis' ? reconciledDisputedAgent : result.oaOutput;
+  const finalOm = pillar === 'ongoing_monitoring' ? reconciledDisputedAgent : result.omOutput;
+
+  // 8b. Recalculate scores using the canonical formula on the reconciled gaps
+  const scoring = calculateScores(finalCs, finalOa, finalOm);
 
   // 9. Persist the new submission row, linked via parent_assessment_id.
   // Re-assessments preferably share their parent's version_number — the partial
@@ -227,9 +263,9 @@ export async function POST(request: Request) {
   // not fully applied) we fall back to the next available version_number so the
   // feature still works.
   const newAllGaps: Gap[] = [
-    ...result.csOutput.gaps,
-    ...result.oaOutput.gaps,
-    ...result.omOutput.gaps,
+    ...finalCs.gaps,
+    ...finalOa.gaps,
+    ...finalOm.gaps,
   ];
 
   const baseInsert = {
@@ -305,7 +341,7 @@ export async function POST(request: Request) {
 
   // 10. Persist gaps for the new submission row
   const newGapRows = [
-    ...result.csOutput.gaps.map((g) => ({
+    ...finalCs.gaps.map((g) => ({
       submission_id: reassessmentId,
       user_id: userId,
       pillar: 'conceptual_soundness' as const,
@@ -315,7 +351,7 @@ export async function POST(request: Request) {
       description: g.description,
       recommendation: g.recommendation,
     })),
-    ...result.oaOutput.gaps.map((g) => ({
+    ...finalOa.gaps.map((g) => ({
       submission_id: reassessmentId,
       user_id: userId,
       pillar: 'outcomes_analysis' as const,
@@ -325,7 +361,7 @@ export async function POST(request: Request) {
       description: g.description,
       recommendation: g.recommendation,
     })),
-    ...result.omOutput.gaps.map((g) => ({
+    ...finalOm.gaps.map((g) => ({
       submission_id: reassessmentId,
       user_id: userId,
       pillar: 'ongoing_monitoring' as const,
@@ -354,7 +390,7 @@ export async function POST(request: Request) {
   const { error: evalError } = await db.from('evals').insert({
     submission_id: reassessmentId,
     input_text_hash: inputTextHash,
-    agent_outputs: { cs: result.csOutput, oa: result.oaOutput, om: result.omOutput },
+    agent_outputs: { cs: finalCs, oa: finalOa, om: finalOm },
     judge_output: result.judgeOutput,
     retry_count: result.retryCount,
     total_latency_ms: Date.now() - requestStartTime,
@@ -368,12 +404,7 @@ export async function POST(request: Request) {
     Sentry.captureException(evalError);
   }
 
-  const disputedAgent = disputedPillarOutput(
-    pillar,
-    result.csOutput,
-    result.oaOutput,
-    result.omOutput
-  );
+  const disputedAgent = disputedPillarOutput(pillar, finalCs, finalOa, finalOm);
   const disputeResolutions: DisputeResolutionItem[] = disputedAgent.dispute_resolutions ?? [];
 
   return NextResponse.json(

--- a/src/app/api/submissions/[id]/compare/[reassessmentId]/route.ts
+++ b/src/app/api/submissions/[id]/compare/[reassessmentId]/route.ts
@@ -1,15 +1,30 @@
 import { NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import { createServerClient } from '@/lib/supabase/server';
+import { createServerClient, createServiceClient } from '@/lib/supabase/server';
 import { errorResponse } from '@/lib/errors/messages';
 import {
+  DisputeResolutionItemSchema,
   UuidParamSchema,
-  type GapWithId,
   type DisputeEventRow,
+  type DisputeResolutionItem,
+  type GapWithId,
   type SubmissionDetail,
 } from '@/lib/validation/schemas';
 import { deriveStatus } from '@/lib/scoring/calculator';
-import { pillarFromElementCode } from '@/lib/agents/scopedReassessment';
+import { pillarFromElementCode, type Pillar } from '@/lib/agents/scopedReassessment';
+import { z } from 'zod';
+
+const AgentOutputsBlobSchema = z.object({
+  cs: z.object({ dispute_resolutions: z.array(DisputeResolutionItemSchema).optional() }).passthrough(),
+  oa: z.object({ dispute_resolutions: z.array(DisputeResolutionItemSchema).optional() }).passthrough(),
+  om: z.object({ dispute_resolutions: z.array(DisputeResolutionItemSchema).optional() }).passthrough(),
+});
+
+function pillarKey(pillar: Pillar): 'cs' | 'oa' | 'om' {
+  if (pillar === 'conceptual_soundness') return 'cs';
+  if (pillar === 'outcomes_analysis') return 'oa';
+  return 'om';
+}
 
 interface RawSubmissionRow {
   id: string;
@@ -225,6 +240,32 @@ export async function GET(
       }
     });
 
+    // Fetch dispute_resolutions from the eval row that the disputes route
+    // wrote when this re-assessment was created. evals is service-role only,
+    // so use the service client. Ownership has already been verified above.
+    let disputeResolutions: DisputeResolutionItem[] = [];
+    {
+      const serviceDb = createServiceClient();
+      const { data: evalRow, error: evalErr } = await serviceDb
+        .from('evals')
+        .select('agent_outputs')
+        .eq('submission_id', reRow.id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (evalErr) {
+        // Non-fatal — surface empty list and continue
+        Sentry.captureException(evalErr);
+      } else if (evalRow?.agent_outputs) {
+        const parsed = AgentOutputsBlobSchema.safeParse(evalRow.agent_outputs);
+        if (parsed.success) {
+          const key = pillarKey(pillarReassessed);
+          disputeResolutions = parsed.data[key].dispute_resolutions ?? [];
+        }
+      }
+    }
+
     return NextResponse.json({
       parent: rowToDetail(parentRow, parentGaps),
       reassessment: {
@@ -240,6 +281,7 @@ export async function GET(
         severity_changed: severityChanged,
       },
       dispute_events: disputeEvents,
+      dispute_resolutions: disputeResolutions,
     });
   } catch (err) {
     Sentry.captureException(err);

--- a/src/app/api/submissions/[id]/compare/[reassessmentId]/route.ts
+++ b/src/app/api/submissions/[id]/compare/[reassessmentId]/route.ts
@@ -132,28 +132,42 @@ export async function GET(
     const parentGaps = (parentGapsRaw ?? []) as GapWithId[];
     const reGaps = (reGapsRaw ?? []) as GapWithId[];
 
-    // Fetch dispute events that triggered this re-assessment.
-    // Filter by parent.id and the parent's gap ids — multiple disputes may exist
-    // for one assessment, but only those linked to gaps belonging to this re-run
-    // are surfaced. For the v1 single-dispute flow this collapses to one row.
-    const parentGapIds = parentGaps.map((g) => g.id);
-    let disputeEvents: DisputeEventRow[] = [];
-    if (parentGapIds.length > 0) {
-      const { data: deRaw, error: deErr } = await supabase
-        .from('dispute_events')
-        .select(
-          'id, assessment_id, gap_id, user_id, dispute_type, reviewer_rationale, proposed_resolution, created_at'
-        )
-        .eq('assessment_id', parentRow.id)
-        .lte('created_at', reRow.created_at)
-        .order('created_at', { ascending: true });
+    // Fetch dispute events that triggered THIS specific re-assessment.
+    // Without a foreign key from dispute_events to the produced re-run, we scope
+    // by time window: disputes filed after the previous re-assessment of this
+    // parent (or after the parent itself if this is the first re-run) and at or
+    // before this re-assessment's creation time.
+    const { data: prevReRaw, error: prevReErr } = await supabase
+      .from('submissions')
+      .select('created_at')
+      .eq('parent_assessment_id', parentRow.id)
+      .lt('created_at', reRow.created_at)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
 
-      if (deErr) {
-        Sentry.captureException(deErr);
-        return errorResponse('DATABASE_ERROR');
-      }
-      disputeEvents = (deRaw ?? []) as DisputeEventRow[];
+    if (prevReErr) {
+      Sentry.captureException(prevReErr);
+      return errorResponse('DATABASE_ERROR');
     }
+
+    const lowerBound = (prevReRaw?.created_at as string | undefined) ?? parentRow.created_at;
+
+    const { data: deRaw, error: deErr } = await supabase
+      .from('dispute_events')
+      .select(
+        'id, assessment_id, gap_id, user_id, dispute_type, reviewer_rationale, proposed_resolution, created_at'
+      )
+      .eq('assessment_id', parentRow.id)
+      .gt('created_at', lowerBound)
+      .lte('created_at', reRow.created_at)
+      .order('created_at', { ascending: true });
+
+    if (deErr) {
+      Sentry.captureException(deErr);
+      return errorResponse('DATABASE_ERROR');
+    }
+    const disputeEvents = (deRaw ?? []) as DisputeEventRow[];
 
     // Compute pillar reassessed (from the dispute event if present, else infer
     // from the first changed pillar score)

--- a/src/app/api/submissions/[id]/compare/[reassessmentId]/route.ts
+++ b/src/app/api/submissions/[id]/compare/[reassessmentId]/route.ts
@@ -1,0 +1,234 @@
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import { createServerClient } from '@/lib/supabase/server';
+import { errorResponse } from '@/lib/errors/messages';
+import {
+  UuidParamSchema,
+  type GapWithId,
+  type DisputeEventRow,
+  type SubmissionDetail,
+} from '@/lib/validation/schemas';
+import { deriveStatus } from '@/lib/scoring/calculator';
+import { pillarFromElementCode } from '@/lib/agents/scopedReassessment';
+
+interface RawSubmissionRow {
+  id: string;
+  user_id: string;
+  version_number: number;
+  document_text: string;
+  conceptual_score: number | string;
+  outcomes_score: number | string;
+  monitoring_score: number | string;
+  final_score: number | string;
+  judge_confidence: number | string;
+  assessment_confidence_label: SubmissionDetail['assessment_confidence_label'];
+  created_at: string;
+  parent_assessment_id: string | null;
+  low_confidence_manual_review: boolean;
+  models: { model_name: string } | null;
+}
+
+const SUBMISSION_SELECT =
+  'id, user_id, version_number, document_text, conceptual_score, outcomes_score, monitoring_score, final_score, judge_confidence, assessment_confidence_label, created_at, parent_assessment_id, low_confidence_manual_review, models(model_name)';
+
+function rowToDetail(row: RawSubmissionRow, gaps: GapWithId[]): SubmissionDetail {
+  const finalScore = Number(row.final_score);
+  return {
+    id: row.id,
+    model_name: row.models?.model_name ?? 'Unknown',
+    version_number: row.version_number,
+    conceptual_score: Number(row.conceptual_score),
+    outcomes_score: Number(row.outcomes_score),
+    monitoring_score: Number(row.monitoring_score),
+    final_score: finalScore,
+    status: deriveStatus(finalScore),
+    assessment_confidence_label: row.assessment_confidence_label,
+    created_at: row.created_at,
+    document_text: row.document_text,
+    gap_analysis: gaps,
+    judge_confidence: Number(row.judge_confidence),
+  };
+}
+
+function gapKey(elementCode: string): string {
+  return elementCode;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; reassessmentId: string }> }
+) {
+  let supabase;
+  try {
+    supabase = await createServerClient();
+  } catch (err) {
+    Sentry.captureException(err);
+    return errorResponse('UNKNOWN_ERROR');
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return errorResponse('AUTH_REQUIRED');
+  }
+
+  const { id, reassessmentId } = await params;
+  const idParse = UuidParamSchema.safeParse({ id });
+  const reIdParse = UuidParamSchema.safeParse({ id: reassessmentId });
+  if (!idParse.success || !reIdParse.success) {
+    return errorResponse('VALIDATION_ERROR', { message: 'Invalid submission ID.' });
+  }
+
+  try {
+    // Fetch both submissions in parallel
+    const [{ data: parentRowRaw, error: parentErr }, { data: reRowRaw, error: reErr }] =
+      await Promise.all([
+        supabase.from('submissions').select(SUBMISSION_SELECT).eq('id', id).maybeSingle(),
+        supabase
+          .from('submissions')
+          .select(SUBMISSION_SELECT)
+          .eq('id', reassessmentId)
+          .maybeSingle(),
+      ]);
+
+    if (parentErr || reErr) {
+      Sentry.captureException(parentErr ?? reErr);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    const parentRow = parentRowRaw as unknown as RawSubmissionRow | null;
+    const reRow = reRowRaw as unknown as RawSubmissionRow | null;
+
+    if (!parentRow || parentRow.user_id !== user.id) {
+      return errorResponse('SUBMISSION_NOT_FOUND');
+    }
+    if (!reRow || reRow.user_id !== user.id) {
+      return errorResponse('SUBMISSION_NOT_FOUND');
+    }
+    if (reRow.parent_assessment_id !== parentRow.id) {
+      return errorResponse('SUBMISSION_NOT_FOUND');
+    }
+
+    // Fetch gaps for both submissions in parallel
+    const [{ data: parentGapsRaw, error: pgErr }, { data: reGapsRaw, error: rgErr }] =
+      await Promise.all([
+        supabase
+          .from('gaps')
+          .select('id, element_code, element_name, severity, description, recommendation')
+          .eq('submission_id', parentRow.id),
+        supabase
+          .from('gaps')
+          .select('id, element_code, element_name, severity, description, recommendation')
+          .eq('submission_id', reRow.id),
+      ]);
+
+    if (pgErr || rgErr) {
+      Sentry.captureException(pgErr ?? rgErr);
+      return errorResponse('DATABASE_ERROR');
+    }
+
+    const parentGaps = (parentGapsRaw ?? []) as GapWithId[];
+    const reGaps = (reGapsRaw ?? []) as GapWithId[];
+
+    // Fetch dispute events that triggered this re-assessment.
+    // Filter by parent.id and the parent's gap ids — multiple disputes may exist
+    // for one assessment, but only those linked to gaps belonging to this re-run
+    // are surfaced. For the v1 single-dispute flow this collapses to one row.
+    const parentGapIds = parentGaps.map((g) => g.id);
+    let disputeEvents: DisputeEventRow[] = [];
+    if (parentGapIds.length > 0) {
+      const { data: deRaw, error: deErr } = await supabase
+        .from('dispute_events')
+        .select(
+          'id, assessment_id, gap_id, user_id, dispute_type, reviewer_rationale, proposed_resolution, created_at'
+        )
+        .eq('assessment_id', parentRow.id)
+        .lte('created_at', reRow.created_at)
+        .order('created_at', { ascending: true });
+
+      if (deErr) {
+        Sentry.captureException(deErr);
+        return errorResponse('DATABASE_ERROR');
+      }
+      disputeEvents = (deRaw ?? []) as DisputeEventRow[];
+    }
+
+    // Compute pillar reassessed (from the dispute event if present, else infer
+    // from the first changed pillar score)
+    let pillarReassessed: 'conceptual_soundness' | 'outcomes_analysis' | 'ongoing_monitoring' =
+      'conceptual_soundness';
+    if (disputeEvents.length > 0) {
+      const firstDispute = disputeEvents[0];
+      const matchingGap = parentGaps.find((g) => g.id === firstDispute.gap_id);
+      if (matchingGap) {
+        pillarReassessed = pillarFromElementCode(matchingGap.element_code);
+      }
+    }
+
+    // Compute pillar deltas (reassessment minus parent)
+    const deltas = {
+      conceptual_soundness:
+        Number(reRow.conceptual_score) - Number(parentRow.conceptual_score),
+      outcomes_analysis: Number(reRow.outcomes_score) - Number(parentRow.outcomes_score),
+      ongoing_monitoring:
+        Number(reRow.monitoring_score) - Number(parentRow.monitoring_score),
+      final_score: Number(reRow.final_score) - Number(parentRow.final_score),
+    };
+
+    // Compute gap diff keyed by element_code
+    const parentByCode = new Map<string, GapWithId>();
+    parentGaps.forEach((g) => parentByCode.set(gapKey(g.element_code), g));
+    const reByCode = new Map<string, GapWithId>();
+    reGaps.forEach((g) => reByCode.set(gapKey(g.element_code), g));
+
+    const removed: GapWithId[] = [];
+    const added: GapWithId[] = [];
+    const severityChanged: Array<{
+      element_code: string;
+      element_name: string;
+      before: GapWithId['severity'];
+      after: GapWithId['severity'];
+    }> = [];
+
+    parentByCode.forEach((parentGap, code) => {
+      const reGap = reByCode.get(code);
+      if (!reGap) {
+        removed.push(parentGap);
+      } else if (reGap.severity !== parentGap.severity) {
+        severityChanged.push({
+          element_code: parentGap.element_code,
+          element_name: parentGap.element_name,
+          before: parentGap.severity,
+          after: reGap.severity,
+        });
+      }
+    });
+    reByCode.forEach((reGap, code) => {
+      if (!parentByCode.has(code)) {
+        added.push(reGap);
+      }
+    });
+
+    return NextResponse.json({
+      parent: rowToDetail(parentRow, parentGaps),
+      reassessment: {
+        ...rowToDetail(reRow, reGaps),
+        parent_assessment_id: reRow.parent_assessment_id!,
+        low_confidence_manual_review: reRow.low_confidence_manual_review,
+      },
+      pillar_reassessed: pillarReassessed,
+      pillar_score_deltas: deltas,
+      gap_diff: {
+        added,
+        removed,
+        severity_changed: severityChanged,
+      },
+      dispute_events: disputeEvents,
+    });
+  } catch (err) {
+    Sentry.captureException(err);
+    return errorResponse('DATABASE_ERROR');
+  }
+}

--- a/src/app/api/submissions/[id]/route.ts
+++ b/src/app/api/submissions/[id]/route.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/nextjs';
 import { createServerClient } from '@/lib/supabase/server';
 import { errorResponse } from '@/lib/errors/messages';
 import { UuidParamSchema } from '@/lib/validation/schemas';
-import type { SubmissionDetail, Gap } from '@/lib/validation/schemas';
+import type { SubmissionDetail, GapWithId } from '@/lib/validation/schemas';
 import { deriveStatus } from '@/lib/scoring/calculator';
 
 export async function GET(
@@ -60,7 +60,7 @@ export async function GET(
     // Fetch gaps from normalized table
     const { data: gapRows, error: gapsError } = await supabase
       .from('gaps')
-      .select('element_code, element_name, severity, description, recommendation')
+      .select('id, element_code, element_name, severity, description, recommendation')
       .eq('submission_id', submissionId);
 
     if (gapsError) {
@@ -83,7 +83,7 @@ export async function GET(
       assessment_confidence_label: row.assessment_confidence_label as SubmissionDetail['assessment_confidence_label'],
       created_at: row.created_at,
       document_text: row.document_text,
-      gap_analysis: (gapRows ?? []) as Gap[],
+      gap_analysis: (gapRows ?? []) as GapWithId[],
       judge_confidence: Number(row.judge_confidence),
     };
 

--- a/src/components/compliance/DisputeModal.tsx
+++ b/src/components/compliance/DisputeModal.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useState } from "react";
+import Modal from "@/components/ui/Modal";
+import Button from "@/components/ui/Button";
+import TextArea from "@/components/ui/TextArea";
+import Skeleton from "@/components/ui/Skeleton";
+import type {
+  DisputeType,
+  GapWithId,
+  ReassessmentResponse,
+} from "@/lib/validation/schemas";
+
+interface DisputeModalProps {
+  open: boolean;
+  onClose: () => void;
+  assessmentId: string;
+  gap: GapWithId | null;
+  onSuccess: (response: ReassessmentResponse) => void;
+}
+
+interface DisputeFormProps {
+  assessmentId: string;
+  gap: GapWithId;
+  onCancel: () => void;
+  onSuccess: (response: ReassessmentResponse) => void;
+}
+
+const DISPUTE_TYPES: ReadonlyArray<{ value: DisputeType; label: string; help: string }> = [
+  {
+    value: "false_positive",
+    label: "False positive",
+    help: "The gap is not actually missing — the document covers this element.",
+  },
+  {
+    value: "wrong_severity",
+    label: "Wrong severity",
+    help: "The gap exists, but the severity (Critical/Major/Minor) is mis-rated.",
+  },
+  {
+    value: "missing_context",
+    label: "Missing context",
+    help: "The agent missed context elsewhere in the document that changes the finding.",
+  },
+];
+
+const RATIONALE_MIN = 10;
+const RATIONALE_MAX = 2000;
+const RESOLUTION_MAX = 2000;
+
+const LABEL_STYLE: React.CSSProperties = {
+  display: "block",
+  fontFamily: "var(--font-geist)",
+  fontSize: "11px",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--color-text-secondary)",
+  marginBottom: "8px",
+};
+
+const FIELD_HINT_STYLE: React.CSSProperties = {
+  fontFamily: "var(--font-geist)",
+  fontSize: "11px",
+  color: "var(--color-text-secondary)",
+  marginTop: "6px",
+};
+
+const ERROR_STYLE: React.CSSProperties = {
+  fontFamily: "var(--font-geist)",
+  fontSize: "12px",
+  color: "var(--color-critical)",
+  marginTop: "10px",
+};
+
+function PendingState() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <div
+        style={{
+          fontFamily: "var(--font-geist)",
+          fontSize: "13px",
+          color: "var(--color-text-primary)",
+        }}
+      >
+        Re-running the affected pillar with your rationale&hellip;
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-geist)",
+          fontSize: "11px",
+          color: "var(--color-text-secondary)",
+        }}
+      >
+        This typically takes 10&ndash;30 seconds.
+      </div>
+      <Skeleton height={12} style={{ width: "100%" }} />
+      <Skeleton height={12} style={{ width: "85%" }} />
+      <Skeleton height={12} style={{ width: "92%" }} />
+      <Skeleton height={12} style={{ width: "70%" }} />
+    </div>
+  );
+}
+
+function DisputeForm({ assessmentId, gap, onCancel, onSuccess }: DisputeFormProps) {
+  const [disputeType, setDisputeType] = useState<DisputeType>("false_positive");
+  const [rationale, setRationale] = useState("");
+  const [resolution, setResolution] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const rationaleValid =
+    rationale.trim().length >= RATIONALE_MIN && rationale.length <= RATIONALE_MAX;
+  const resolutionValid = resolution.length <= RESOLUTION_MAX;
+  const canSubmit = rationaleValid && resolutionValid && !submitting;
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/disputes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          assessment_id: assessmentId,
+          gap_id: gap.id,
+          dispute_type: disputeType,
+          reviewer_rationale: rationale.trim(),
+          proposed_resolution: resolution.trim() || undefined,
+        }),
+      });
+
+      if (res.status === 401) {
+        window.location.href = "/login";
+        return;
+      }
+
+      const body = (await res.json().catch(() => null)) as
+        | (ReassessmentResponse & { message?: string })
+        | { message?: string }
+        | null;
+
+      if (!res.ok) {
+        const msg =
+          (body && "message" in body && body.message) ||
+          "Re-assessment failed. Please try again.";
+        setError(msg);
+        setSubmitting(false);
+        return;
+      }
+
+      onSuccess(body as ReassessmentResponse);
+    } catch {
+      setError("Network error. Please try again.");
+      setSubmitting(false);
+    }
+  }
+
+  if (submitting) {
+    return <PendingState />;
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+      {/* Gap context */}
+      <div
+        style={{
+          background: "var(--color-bg-tertiary)",
+          border: "1px solid var(--color-border)",
+          padding: "12px",
+          borderRadius: "2px",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: "var(--font-ibm-plex-mono)",
+            fontSize: "11px",
+            color: "var(--color-accent)",
+            marginBottom: "4px",
+          }}
+        >
+          {gap.element_code} &middot; {gap.severity}
+        </div>
+        <div
+          style={{
+            fontFamily: "var(--font-geist)",
+            fontSize: "12px",
+            color: "var(--color-text-primary)",
+            lineHeight: 1.5,
+          }}
+        >
+          {gap.description}
+        </div>
+      </div>
+
+      {/* Dispute type */}
+      <div>
+        <label style={LABEL_STYLE}>Dispute type</label>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {DISPUTE_TYPES.map((t) => (
+            <label
+              key={t.value}
+              style={{
+                display: "flex",
+                gap: "10px",
+                alignItems: "flex-start",
+                cursor: "pointer",
+                padding: "8px 10px",
+                border: "1px solid var(--color-border)",
+                borderRadius: "2px",
+                background:
+                  disputeType === t.value
+                    ? "color-mix(in srgb, var(--color-accent) 8%, var(--color-bg-tertiary))"
+                    : "var(--color-bg-tertiary)",
+              }}
+            >
+              <input
+                type="radio"
+                name="dispute_type"
+                value={t.value}
+                checked={disputeType === t.value}
+                onChange={() => setDisputeType(t.value)}
+                style={{ marginTop: "3px", accentColor: "var(--color-accent)" }}
+              />
+              <div>
+                <div
+                  style={{
+                    fontFamily: "var(--font-geist)",
+                    fontSize: "13px",
+                    fontWeight: 500,
+                    color: "var(--color-text-primary)",
+                  }}
+                >
+                  {t.label}
+                </div>
+                <div
+                  style={{
+                    fontFamily: "var(--font-geist)",
+                    fontSize: "11px",
+                    color: "var(--color-text-secondary)",
+                    marginTop: "2px",
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {t.help}
+                </div>
+              </div>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Rationale */}
+      <div>
+        <label style={LABEL_STYLE}>Reviewer rationale (required)</label>
+        <TextArea
+          value={rationale}
+          onChange={setRationale}
+          placeholder="Explain why you disagree with this finding."
+          rows={4}
+          maxLength={RATIONALE_MAX}
+        />
+        <div style={FIELD_HINT_STYLE}>
+          {rationale.trim().length}/{RATIONALE_MAX} &middot; minimum {RATIONALE_MIN} characters
+        </div>
+      </div>
+
+      {/* Proposed resolution */}
+      <div>
+        <label style={LABEL_STYLE}>Proposed resolution (optional)</label>
+        <TextArea
+          value={resolution}
+          onChange={setResolution}
+          placeholder="Suggest how the agent should handle this on re-assessment."
+          rows={3}
+          maxLength={RESOLUTION_MAX}
+        />
+      </div>
+
+      {error ? <div style={ERROR_STYLE}>{error}</div> : null}
+
+      <div
+        style={{
+          display: "flex",
+          gap: "10px",
+          justifyContent: "flex-end",
+          marginTop: "4px",
+        }}
+      >
+        <Button variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="primary" disabled={!canSubmit} onClick={handleSubmit}>
+          Submit & Re-assess
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function DisputeModal({
+  open,
+  onClose,
+  assessmentId,
+  gap,
+  onSuccess,
+}: DisputeModalProps) {
+  return (
+    <Modal open={open} onClose={onClose} title="Dispute Finding">
+      {gap ? (
+        <DisputeForm
+          key={gap.id}
+          assessmentId={assessmentId}
+          gap={gap}
+          onCancel={onClose}
+          onSuccess={onSuccess}
+        />
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/components/compliance/GapAnalysisTable.tsx
+++ b/src/components/compliance/GapAnalysisTable.tsx
@@ -4,8 +4,11 @@ import { useMemo } from "react";
 import { motion } from "framer-motion";
 import type { Gap } from "@/lib/validation/schemas";
 
+type GapWithOptionalId = Gap & { id?: string };
+
 interface GapAnalysisTableProps {
-  gaps: Gap[];
+  gaps: GapWithOptionalId[];
+  onDispute?: (gap: GapWithOptionalId & { id: string }) => void;
 }
 
 const SEVERITY_ORDER: Record<string, number> = {
@@ -82,7 +85,7 @@ function getPillarLabel(elementCode: string): string {
   return PILLAR_LABELS[prefix] ?? prefix;
 }
 
-export default function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
+export default function GapAnalysisTable({ gaps, onDispute }: GapAnalysisTableProps) {
   const sorted = useMemo(
     () =>
       [...gaps].sort(
@@ -134,6 +137,7 @@ export default function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
               <th style={TH_STYLE}>Pillar</th>
               <th style={TH_STYLE}>Description</th>
               <th style={TH_STYLE}>Recommendation</th>
+              {onDispute ? <th style={TH_STYLE}>Action</th> : null}
             </tr>
           </thead>
           <tbody>
@@ -200,6 +204,29 @@ export default function GapAnalysisTable({ gaps }: GapAnalysisTableProps) {
                 >
                   {gap.recommendation}
                 </td>
+                {onDispute ? (
+                  <td style={{ ...TD_STYLE, whiteSpace: "nowrap" }}>
+                    {gap.id ? (
+                      <button
+                        type="button"
+                        onClick={() => onDispute({ ...gap, id: gap.id! })}
+                        style={{
+                          fontFamily: "var(--font-geist)",
+                          fontSize: "11px",
+                          fontWeight: 500,
+                          color: "var(--color-accent)",
+                          background: "transparent",
+                          border: "1px solid var(--color-border)",
+                          borderRadius: "2px",
+                          padding: "5px 10px",
+                          cursor: "pointer",
+                        }}
+                      >
+                        Dispute
+                      </button>
+                    ) : null}
+                  </td>
+                ) : null}
               </motion.tr>
             ))}
           </tbody>

--- a/src/lib/agents/judge.ts
+++ b/src/lib/agents/judge.ts
@@ -37,6 +37,13 @@ Did the OM agent address all 6 elements (OM-01 through OM-06)?
 7. SEVERITY CALIBRATION
 Are the severity ratings appropriate? Critical should mean the element is completely absent. If an agent marked something Critical but the description suggests the element is present but incomplete, flag this as miscalibrated.
 
+8. DISPUTE RESOLUTION QUALITY (only when the user prompt contains a <reviewer_dispute_context> block)
+The disputed pillar agent produced a "dispute_resolutions" array — one entry per disputed gap — under the rules in that block. Verify each resolution is well-reasoned:
+- "reversed_with_evidence" / "severity_adjusted_with_evidence" require the agent's note to cite specific document content (section, paragraph, table, figure, or quote). If the rationale was vague (e.g. "smoke test", "I disagree") and the agent still reversed or adjusted, flag this as insufficient evidence.
+- "retained_insufficient_evidence" / "retained_evidence_supports_original" require the agent's note to explain why the rationale failed the evidentiary tier OR which document content supports the original finding.
+- Severity tiers: Critical reversals demand directly addressing content; Major reversals demand relevant content; Minor reversals demand a reasonable document reference. Flag mismatches.
+Add issues to the disputed pillar's agent_feedback.issues when dispute_resolutions are not well-reasoned. This check does not apply when no <reviewer_dispute_context> block is present.
+
 CONFIDENCE SCORING RULES:
 - 0.9-1.0: All consistency checks pass, math checks out, no anomalies detected
 - 0.7-0.89: Minor issues found (1-2 small inconsistencies), overall assessment trustworthy

--- a/src/lib/agents/scopedReassessment.ts
+++ b/src/lib/agents/scopedReassessment.ts
@@ -32,7 +32,40 @@ function buildReviewerDisputeContext(
   });
 
   return `<reviewer_dispute_context>
-A human reviewer has disputed one or more of your previous findings on this pillar. Use the dispute(s) below as additional expert signal during your re-assessment. Apply your own SR 11-7 judgement — do not blindly accept or reject the rationale.
+A human reviewer has disputed one or more of your previous findings on this pillar.
+
+HOW TO USE THIS CONTEXT:
+The reviewer's rationale is a HYPOTHESIS to test against the document. It is NOT a directive to follow. Your job is to verify the rationale against the document and apply SR 11-7 evidentiary standards. Do not reverse a finding because the reviewer asserts you were wrong — reverse it only when the document supports the reviewer's claim.
+
+EVIDENCE REQUIREMENT:
+To reverse a finding (or change its severity), the rationale must reference SPECIFIC document content — a section number, paragraph, table, figure, or quoted text — that contradicts your original finding. Vague rationales such as "I disagree", "smoke test", "this is fine", or unsupported assertions are INSUFFICIENT to reverse any finding.
+
+EVIDENTIARY THRESHOLDS BY SEVERITY:
+- Critical findings: reverse only if the rationale points to specific document content that DIRECTLY addresses the missing element. The cited content must, on its own, satisfy the SR 11-7 element. A mere mention or oblique reference is not enough.
+- Major findings: reverse if the rationale points to relevant document content, even if that content does not fully address the element. The cited content must be specific enough that you can locate it.
+- Minor findings: reverse on reasonable rationale that references the document. A pointer to the relevant section is sufficient even without a direct quotation.
+
+Severity changes (up or down) follow the SAME evidentiary rules as reversals — promote or demote a severity only if the document evidence supports the change at the appropriate tier.
+
+WHEN EVIDENCE IS INSUFFICIENT:
+If the rationale lacks specific document evidence for the severity tier above, you MUST retain the original finding. Note this explicitly — do not be persuaded by tone, reviewer authority, or the dispute_type label alone.
+
+REQUIRED OUTPUT EXTENSION:
+In addition to the standard JSON output schema described in your system prompt, you MUST include a top-level field named "dispute_resolutions". It is an array with EXACTLY one entry per dispute listed below. Each entry uses this shape:
+
+{
+  "element_code": "<the disputed element_code>",
+  "resolution": "<one of: reversed_with_evidence | severity_adjusted_with_evidence | retained_insufficient_evidence | retained_evidence_supports_original>",
+  "note": "<≤500 chars: cite the document evidence you relied on, OR state which evidence the rationale failed to provide>"
+}
+
+Resolution semantics:
+- "reversed_with_evidence": the gap was removed from your gaps array because the rationale's document references satisfy the element at the required evidentiary tier.
+- "severity_adjusted_with_evidence": the gap remains in your gaps array but at a different severity, justified by the rationale's document references.
+- "retained_insufficient_evidence": the rationale did NOT provide specific document evidence at the required tier; original finding kept unchanged.
+- "retained_evidence_supports_original": the rationale referenced the document but the cited content actually supports your original finding (e.g. confirms the gap is real); original finding kept unchanged.
+
+DISPUTES:
 
 ${items.join('\n\n')}
 </reviewer_dispute_context>`;
@@ -80,7 +113,7 @@ export async function runScopedReassessment(
       omOutput = await assessOngoingMonitoring(input.documentText, input.modelName, reviewerContext);
     }
 
-    judgeOutput = await runJudge(input.modelName, csOutput, oaOutput, omOutput);
+    judgeOutput = await runJudge(input.modelName, csOutput, oaOutput, omOutput, reviewerContext);
 
     if (judgeOutput.confidence >= REASSESS_CONFIDENCE_THRESHOLD || retryCount >= MAX_REASSESS_RETRIES) {
       break;

--- a/src/lib/agents/scopedReassessment.ts
+++ b/src/lib/agents/scopedReassessment.ts
@@ -1,0 +1,102 @@
+import { assessConceptualSoundness } from '@/lib/agents/conceptualSoundness';
+import { assessOutcomesAnalysis } from '@/lib/agents/outcomesAnalysis';
+import { assessOngoingMonitoring } from '@/lib/agents/ongoingMonitoring';
+import { runJudge } from '@/lib/agents/judge';
+import type { AgentOutput, DisputeRequest, JudgeOutput, PillarEnum } from '@/lib/validation/schemas';
+import type { z } from 'zod';
+
+export type Pillar = z.infer<typeof PillarEnum>;
+
+const REASSESS_CONFIDENCE_THRESHOLD = 0.7;
+const MAX_REASSESS_RETRIES = 1;
+
+export function pillarFromElementCode(code: string): Pillar {
+  if (code.startsWith('CS-')) return 'conceptual_soundness';
+  if (code.startsWith('OA-')) return 'outcomes_analysis';
+  if (code.startsWith('OM-')) return 'ongoing_monitoring';
+  throw new Error(`Unknown element code prefix: ${code}`);
+}
+
+function buildReviewerDisputeContext(
+  disputes: ReadonlyArray<Pick<DisputeRequest, 'dispute_type' | 'reviewer_rationale' | 'proposed_resolution'> & { element_code: string }>
+): string {
+  const items = disputes.map((d, i) => {
+    const lines = [
+      `[Dispute ${i + 1}]`,
+      `Element: ${d.element_code}`,
+      `Type: ${d.dispute_type}`,
+      `Reviewer rationale: ${d.reviewer_rationale}`,
+    ];
+    if (d.proposed_resolution) lines.push(`Proposed resolution: ${d.proposed_resolution}`);
+    return lines.join('\n');
+  });
+
+  return `<reviewer_dispute_context>
+A human reviewer has disputed one or more of your previous findings on this pillar. Use the dispute(s) below as additional expert signal during your re-assessment. Apply your own SR 11-7 judgement — do not blindly accept or reject the rationale.
+
+${items.join('\n\n')}
+</reviewer_dispute_context>`;
+}
+
+export interface ScopedReassessmentResult {
+  csOutput: AgentOutput;
+  oaOutput: AgentOutput;
+  omOutput: AgentOutput;
+  judgeOutput: JudgeOutput;
+  retryCount: number;
+  pillarReassessed: Pillar;
+  lowConfidenceManualReview: boolean;
+}
+
+export interface ScopedReassessmentInput {
+  documentText: string;
+  modelName: string;
+  pillar: Pillar;
+  previousCsOutput: AgentOutput;
+  previousOaOutput: AgentOutput;
+  previousOmOutput: AgentOutput;
+  disputes: ReadonlyArray<
+    Pick<DisputeRequest, 'dispute_type' | 'reviewer_rationale' | 'proposed_resolution'> & { element_code: string }
+  >;
+}
+
+export async function runScopedReassessment(
+  input: ScopedReassessmentInput
+): Promise<ScopedReassessmentResult> {
+  const reviewerContext = buildReviewerDisputeContext(input.disputes);
+
+  let csOutput = input.previousCsOutput;
+  let oaOutput = input.previousOaOutput;
+  let omOutput = input.previousOmOutput;
+  let judgeOutput: JudgeOutput | null = null;
+  let retryCount = 0;
+
+  while (true) {
+    if (input.pillar === 'conceptual_soundness') {
+      csOutput = await assessConceptualSoundness(input.documentText, input.modelName, reviewerContext);
+    } else if (input.pillar === 'outcomes_analysis') {
+      oaOutput = await assessOutcomesAnalysis(input.documentText, input.modelName, reviewerContext);
+    } else {
+      omOutput = await assessOngoingMonitoring(input.documentText, input.modelName, reviewerContext);
+    }
+
+    judgeOutput = await runJudge(input.modelName, csOutput, oaOutput, omOutput);
+
+    if (judgeOutput.confidence >= REASSESS_CONFIDENCE_THRESHOLD || retryCount >= MAX_REASSESS_RETRIES) {
+      break;
+    }
+    retryCount++;
+  }
+
+  const lowConfidenceManualReview = judgeOutput!.confidence < REASSESS_CONFIDENCE_THRESHOLD;
+
+  return {
+    csOutput,
+    oaOutput,
+    omOutput,
+    judgeOutput: judgeOutput!,
+    retryCount,
+    pillarReassessed: input.pillar,
+    lowConfidenceManualReview,
+  };
+}

--- a/src/lib/agents/scopedReassessment.ts
+++ b/src/lib/agents/scopedReassessment.ts
@@ -2,7 +2,14 @@ import { assessConceptualSoundness } from '@/lib/agents/conceptualSoundness';
 import { assessOutcomesAnalysis } from '@/lib/agents/outcomesAnalysis';
 import { assessOngoingMonitoring } from '@/lib/agents/ongoingMonitoring';
 import { runJudge } from '@/lib/agents/judge';
-import type { AgentOutput, DisputeRequest, JudgeOutput, PillarEnum } from '@/lib/validation/schemas';
+import type {
+  AgentOutput,
+  DisputeRequest,
+  DisputeResolutionItem,
+  Gap,
+  JudgeOutput,
+  PillarEnum,
+} from '@/lib/validation/schemas';
 import type { z } from 'zod';
 
 export type Pillar = z.infer<typeof PillarEnum>;
@@ -65,10 +72,95 @@ Resolution semantics:
 - "retained_insufficient_evidence": the rationale did NOT provide specific document evidence at the required tier; original finding kept unchanged.
 - "retained_evidence_supports_original": the rationale referenced the document but the cited content actually supports your original finding (e.g. confirms the gap is real); original finding kept unchanged.
 
+CONSISTENCY RULE — your gaps array and dispute_resolutions array MUST agree for every disputed element_code:
+- "retained_insufficient_evidence" / "retained_evidence_supports_original": the disputed element MUST appear in your gaps array at the SAME severity and with the SAME element_code as in the original assessment. Do NOT silently drop a gap you have declared retained.
+- "reversed_with_evidence": the disputed element_code MUST be ABSENT from your gaps array.
+- "severity_adjusted_with_evidence": the disputed element_code MUST appear in your gaps array at a DIFFERENT severity than the original.
+Any mismatch between dispute_resolutions and the gaps array is a critical error and will be reconciled by the system in favour of the dispute_resolution you stated. State retention only when you intend to keep the gap; state reversal only when you intend to remove it.
+
 DISPUTES:
 
 ${items.join('\n\n')}
 </reviewer_dispute_context>`;
+}
+
+/**
+ * Force the agent's gaps array to match the verdicts it declared in
+ * dispute_resolutions. We cannot rely on the LLM being self-consistent — for an
+ * SR 11-7 audit trail the persisted gaps must agree with the stated resolution.
+ * Returns the corrected agent output and any inconsistencies that were caught.
+ */
+export function reconcileDisputeResolutions(args: {
+  agentOutput: AgentOutput;
+  parentPillarGaps: ReadonlyArray<Gap>;
+  disputedElementCodes: ReadonlyArray<string>;
+}): { reconciled: AgentOutput; warnings: string[] } {
+  const warnings: string[] = [];
+
+  const resolutionByCode = new Map<string, DisputeResolutionItem>();
+  for (const r of args.agentOutput.dispute_resolutions ?? []) {
+    resolutionByCode.set(r.element_code, r);
+  }
+
+  const newGapsByCode = new Map<string, Gap>();
+  for (const g of args.agentOutput.gaps) {
+    newGapsByCode.set(g.element_code, g);
+  }
+
+  const parentByCode = new Map<string, Gap>();
+  for (const g of args.parentPillarGaps) {
+    parentByCode.set(g.element_code, g);
+  }
+
+  for (const code of args.disputedElementCodes) {
+    const resolution = resolutionByCode.get(code);
+    const parentGap = parentByCode.get(code);
+    if (!resolution || !parentGap) continue;
+
+    const newGap = newGapsByCode.get(code);
+
+    switch (resolution.resolution) {
+      case 'retained_insufficient_evidence':
+      case 'retained_evidence_supports_original':
+        if (!newGap) {
+          warnings.push(
+            `${code}: declared "${resolution.resolution}" but gap was missing from gaps array — restoring original.`
+          );
+          newGapsByCode.set(code, parentGap);
+        } else if (newGap.severity !== parentGap.severity) {
+          warnings.push(
+            `${code}: declared "${resolution.resolution}" but severity changed ${parentGap.severity}→${newGap.severity} — restoring original severity.`
+          );
+          newGapsByCode.set(code, parentGap);
+        }
+        break;
+      case 'reversed_with_evidence':
+        if (newGap) {
+          warnings.push(
+            `${code}: declared "reversed_with_evidence" but gap was still present — removing.`
+          );
+          newGapsByCode.delete(code);
+        }
+        break;
+      case 'severity_adjusted_with_evidence':
+        if (!newGap) {
+          warnings.push(
+            `${code}: declared "severity_adjusted_with_evidence" but gap was missing — conservatively restoring original.`
+          );
+          newGapsByCode.set(code, parentGap);
+        } else if (newGap.severity === parentGap.severity) {
+          warnings.push(
+            `${code}: declared "severity_adjusted_with_evidence" but severity is unchanged — keeping current severity, but resolution semantics are violated.`
+          );
+        }
+        break;
+    }
+  }
+
+  return {
+    reconciled: { ...args.agentOutput, gaps: Array.from(newGapsByCode.values()) },
+    warnings,
+  };
 }
 
 export interface ScopedReassessmentResult {

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -242,9 +242,15 @@ export const SubmissionListItemSchema = z.object({
 
 export type SubmissionListItem = z.infer<typeof SubmissionListItemSchema>;
 
+export const GapWithIdSchema = GapSchema.extend({
+  id: z.string().uuid(),
+});
+
+export type GapWithId = z.infer<typeof GapWithIdSchema>;
+
 export const SubmissionDetailSchema = SubmissionListItemSchema.extend({
   document_text: z.string().min(100).max(50000),
-  gap_analysis: z.array(GapSchema),
+  gap_analysis: z.array(GapWithIdSchema),
   judge_confidence: z.number().min(0).max(1),
 });
 
@@ -336,3 +342,86 @@ export const DeleteAllConfirmSchema = z.object({
 });
 
 export type DeleteAllConfirm = z.infer<typeof DeleteAllConfirmSchema>;
+
+// ─── Dispute / scoped re-assessment schemas ─────────────────────────────────
+
+export const DisputeTypeEnum = z.enum([
+  "false_positive",
+  "wrong_severity",
+  "missing_context",
+]);
+
+export type DisputeType = z.infer<typeof DisputeTypeEnum>;
+
+export const DisputeRequestSchema = z.object({
+  assessment_id: z.string().uuid("Invalid submission ID"),
+  gap_id: z.string().uuid("Invalid gap ID"),
+  dispute_type: DisputeTypeEnum,
+  reviewer_rationale: z
+    .string()
+    .min(10, "Rationale must be at least 10 characters")
+    .max(2000, "Rationale must be under 2,000 characters"),
+  proposed_resolution: z
+    .string()
+    .max(2000, "Proposed resolution must be under 2,000 characters")
+    .optional(),
+});
+
+export type DisputeRequest = z.infer<typeof DisputeRequestSchema>;
+
+export const DisputeEventRowSchema = z.object({
+  id: z.string().uuid(),
+  assessment_id: z.string().uuid().nullable(),
+  gap_id: z.string().uuid().nullable(),
+  user_id: z.string().uuid(),
+  dispute_type: DisputeTypeEnum,
+  reviewer_rationale: z.string(),
+  proposed_resolution: z.string().nullable(),
+  created_at: z.string().datetime(),
+});
+
+export type DisputeEventRow = z.infer<typeof DisputeEventRowSchema>;
+
+export const ReassessmentResponseSchema = z.object({
+  reassessment_id: z.string().uuid(),
+  parent_assessment_id: z.string().uuid(),
+  pillar_reassessed: PillarEnum,
+  scoring: ScoringResultSchema,
+  judge_confidence: z.number().min(0).max(1),
+  judge_confidence_label: ConfidenceLabelEnum,
+  low_confidence_manual_review: z.boolean(),
+  dispute_event_id: z.string().uuid(),
+  created_at: z.string().datetime(),
+});
+
+export type ReassessmentResponse = z.infer<typeof ReassessmentResponseSchema>;
+
+export const CompareResponseSchema = z.object({
+  parent: SubmissionDetailSchema,
+  reassessment: SubmissionDetailSchema.extend({
+    parent_assessment_id: z.string().uuid(),
+    low_confidence_manual_review: z.boolean(),
+  }),
+  pillar_reassessed: PillarEnum,
+  pillar_score_deltas: z.object({
+    conceptual_soundness: z.number(),
+    outcomes_analysis: z.number(),
+    ongoing_monitoring: z.number(),
+    final_score: z.number(),
+  }),
+  gap_diff: z.object({
+    added: z.array(GapWithIdSchema),
+    removed: z.array(GapWithIdSchema),
+    severity_changed: z.array(
+      z.object({
+        element_code: ElementCodeEnum,
+        element_name: z.string(),
+        before: SeverityEnum,
+        after: SeverityEnum,
+      })
+    ),
+  }),
+  dispute_events: z.array(DisputeEventRowSchema),
+});
+
+export type CompareResponse = z.infer<typeof CompareResponseSchema>;

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -107,6 +107,25 @@ export const GapSchema = z.object({
 
 export type Gap = z.infer<typeof GapSchema>;
 
+// ─── Dispute resolution (agent's per-gap verdict on a reviewer dispute) ─────
+
+export const DisputeResolutionEnum = z.enum([
+  "reversed_with_evidence",
+  "severity_adjusted_with_evidence",
+  "retained_insufficient_evidence",
+  "retained_evidence_supports_original",
+]);
+
+export type DisputeResolution = z.infer<typeof DisputeResolutionEnum>;
+
+export const DisputeResolutionItemSchema = z.object({
+  element_code: ElementCodeEnum,
+  resolution: DisputeResolutionEnum,
+  note: z.string().max(500).optional(),
+});
+
+export type DisputeResolutionItem = z.infer<typeof DisputeResolutionItemSchema>;
+
 // ─── Agent output schema ──────────────────────────────────────────────────────
 
 export const AgentOutputSchema = z.object({
@@ -115,6 +134,9 @@ export const AgentOutputSchema = z.object({
   confidence: z.number().min(0).max(1),
   gaps: z.array(GapSchema),
   summary: z.string().min(1).max(2000),
+  // Populated only on dispute re-runs. One entry per disputed gap, mapping
+  // the original element_code to the agent's verdict on the reviewer's dispute.
+  dispute_resolutions: z.array(DisputeResolutionItemSchema).optional(),
 });
 
 export type AgentOutput = z.infer<typeof AgentOutputSchema>;
@@ -391,6 +413,7 @@ export const ReassessmentResponseSchema = z.object({
   judge_confidence_label: ConfidenceLabelEnum,
   low_confidence_manual_review: z.boolean(),
   dispute_event_id: z.string().uuid(),
+  dispute_resolutions: z.array(DisputeResolutionItemSchema),
   created_at: z.string().datetime(),
 });
 
@@ -422,6 +445,9 @@ export const CompareResponseSchema = z.object({
     ),
   }),
   dispute_events: z.array(DisputeEventRowSchema),
+  // Per-disputed-gap verdict from the disputed pillar agent. Keyed by
+  // element_code so the UI can join with each dispute_event.gap_id ↔ parent gap.
+  dispute_resolutions: z.array(DisputeResolutionItemSchema),
 });
 
 export type CompareResponse = z.infer<typeof CompareResponseSchema>;

--- a/supabase/migrations/20260430_dispute_events.sql
+++ b/supabase/migrations/20260430_dispute_events.sql
@@ -1,0 +1,74 @@
+-- Scoped re-assessment + dispute trail.
+--
+-- - `submissions.parent_assessment_id` links a re-run submission row to its
+--   immutable origin. NULL for original submissions.
+-- - `dispute_events` records every reviewer-filed disagreement that triggered a
+--   re-run. Rows are append-only — no UPDATE/DELETE policies. The trail is the
+--   labeled-disagreement dataset, so it must survive even if a downstream
+--   re-assessment is deleted; on submission delete we SET NULL on assessment_id
+--   so the rationale is preserved.
+
+-- 1. Add parent_assessment_id to submissions ----------------------------------
+
+ALTER TABLE public.submissions
+  ADD COLUMN parent_assessment_id UUID
+    REFERENCES public.submissions(id) ON DELETE SET NULL;
+
+ALTER TABLE public.submissions
+  ADD COLUMN low_confidence_manual_review BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX idx_submissions_parent_assessment_id
+  ON public.submissions(parent_assessment_id)
+  WHERE parent_assessment_id IS NOT NULL;
+
+-- The (model_id, version_number) uniqueness should only apply to original
+-- submissions. Re-assessments share their parent's version_number — they are
+-- not new versions, they are additional opinions on an existing version.
+ALTER TABLE public.submissions
+  DROP CONSTRAINT submissions_model_version_unique;
+
+CREATE UNIQUE INDEX submissions_model_version_unique
+  ON public.submissions(model_id, version_number)
+  WHERE parent_assessment_id IS NULL;
+
+-- 2. Create dispute_events ----------------------------------------------------
+
+CREATE TABLE public.dispute_events (
+  id                   UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  assessment_id        UUID REFERENCES public.submissions(id) ON DELETE SET NULL,
+  gap_id               UUID REFERENCES public.gaps(id)        ON DELETE SET NULL,
+  user_id              UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  dispute_type         TEXT NOT NULL CHECK (
+                         dispute_type IN ('false_positive', 'wrong_severity', 'missing_context')
+                       ),
+  reviewer_rationale   TEXT NOT NULL CHECK (
+                         char_length(trim(reviewer_rationale)) >= 10
+                         AND char_length(reviewer_rationale) <= 2000
+                       ),
+  proposed_resolution  TEXT CHECK (
+                         proposed_resolution IS NULL
+                         OR char_length(proposed_resolution) <= 2000
+                       ),
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_dispute_events_assessment_id ON public.dispute_events(assessment_id);
+CREATE INDEX idx_dispute_events_user_id       ON public.dispute_events(user_id);
+CREATE INDEX idx_dispute_events_gap_id        ON public.dispute_events(gap_id);
+
+-- 3. Row Level Security -------------------------------------------------------
+
+ALTER TABLE public.dispute_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "dispute_events_select_own"
+  ON public.dispute_events
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "dispute_events_insert_own"
+  ON public.dispute_events
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- No UPDATE policy: dispute records are immutable evidence.
+-- No DELETE policy: trail must survive even when associated submissions are removed.

--- a/supabase/migrations/20260430_dispute_events.sql
+++ b/supabase/migrations/20260430_dispute_events.sql
@@ -34,7 +34,7 @@ CREATE UNIQUE INDEX submissions_model_version_unique
 -- 2. Create dispute_events ----------------------------------------------------
 
 CREATE TABLE public.dispute_events (
-  id                   UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   assessment_id        UUID REFERENCES public.submissions(id) ON DELETE SET NULL,
   gap_id               UUID REFERENCES public.gaps(id)        ON DELETE SET NULL,
   user_id              UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- Reviewers can dispute a flagged gap on a submission, supply rationale, and trigger a re-run scoped to just that pillar — the original assessment is immutable and the re-run is persisted as a new row linked via `parent_assessment_id`.
- Every dispute is recorded in an append-only `dispute_events` table. That trail is labeled human/agent disagreement data, so it must survive even if a downstream re-assessment is deleted.
- New compare view at `/submissions/[id]/compare/[reassessmentId]` renders pillar score deltas, the gap diff (added / removed / severity-changed), and the dispute rationale that triggered the re-run.

## What changed
- **Migration `supabase/migrations/20260430_dispute_events.sql`**
  - New `dispute_events` table with RLS (`auth.uid() = user_id`), SELECT/INSERT only — no UPDATE/DELETE policies, so the trail is append-only.
  - `submissions.parent_assessment_id` (FK → submissions, ON DELETE SET NULL) + `submissions.low_confidence_manual_review` boolean.
  - The `(model_id, version_number)` uniqueness becomes a partial unique index `WHERE parent_assessment_id IS NULL` so re-runs share their parent's version_number — they're second opinions on a version, not new versions.
- **Scoped re-run (`src/lib/agents/scopedReassessment.ts`)**
  - Reuses existing pillar agent + judge code paths. Reviewer rationale is injected as a `<reviewer_dispute_context>` block via the existing `retryContext` parameter — no system prompt changes, all bias mitigations preserved.
  - Threshold is **0.7** (vs default 0.6), retry once, otherwise return with `low_confidence_manual_review = true`.
  - Un-disputed pillars are not re-invoked; their outputs are reconstructed from the parent submission's stored `gap_analysis` and passed to `runJudge` so its cross-pillar consistency checks still apply.
  - Final scoring uses `calculateScores` unchanged (CS×0.40 + OA×0.35 + OM×0.25, severities -20/-10/-5).
- **API**
  - `POST /api/disputes` — validates body, persists `dispute_events` row, runs scoped re-run, inserts new `submissions` row with `parent_assessment_id`, inserts new gap rows, returns `ReassessmentResponse`.
  - `GET /api/submissions/[id]/compare/[reassessmentId]` — returns parent + reassessment detail, pillar deltas, gap diff, and dispute event(s).
- **UI**
  - `GapAnalysisTable` gains an optional `onDispute` per-row action.
  - `DisputeModal` captures `dispute_type` (false_positive | wrong_severity | missing_context), required rationale (≥10 chars), optional proposed_resolution. Skeleton-only pending state during the 10–30 s re-run.
  - Compare page renders score deltas (arrows, color-coded, IBM Plex Mono numerics), gap diff, and the dispute rationale.
- **Validation**
  - All new schemas (`DisputeRequestSchema`, `DisputeEventRowSchema`, `ReassessmentResponseSchema`, `CompareResponseSchema`, `GapWithIdSchema`, `DisputeTypeEnum`) live in `src/lib/validation/schemas.ts`.

## Deviations from spec
- Re-runs share their parent's `version_number` via a partial unique index rather than consuming a new version slot — see migration note above. Without this, version numbers would be polluted by re-assessments.
- `low_confidence_manual_review` is also persisted on the submission row (not just returned) so the compare view and any future dashboard surface can read it without recomputing.
- Route directory uses camelCase `[reassessmentId]` (Next.js dynamic-segment convention); URL semantics unchanged.

## Test plan
- [x] `npm run build` — clean compile, all new routes registered
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no errors
- [x] `npm test` — 248 / 248 passing
- [ ] `npm run test:ai` — skipped locally (no `ANTHROPIC_API_KEY` in this environment). The existing baseline path (`runCompliance` with no retry context) is byte-identical to before, so drift is 0 by construction. CI will run this with credentials.
- [ ] Apply the migration to Supabase (manual SQL editor run, like prior schema files in `docs/DATABASE.md`).
- [ ] Manual end-to-end: file dispute → re-run executes → new submission row exists with `parent_assessment_id` set → compare view renders.
- [ ] RLS sanity check: a second user cannot read another user's `dispute_events` (verified via SQL: SELECT/INSERT policies are `auth.uid() = user_id` only).