### PR TITLE
Per-element calibration eval with drafted labels

### DIFF
--- a/jest.ai.config.ts
+++ b/jest.ai.config.ts
@@ -7,7 +7,10 @@ const config: Config = {
     "^@/(.*)$": "<rootDir>/src/$1",
     "^server-only$": "<rootDir>/tests/synthetic/__mocks__/server-only.ts",
   },
-  testMatch: ["<rootDir>/tests/synthetic/runner.test.ts"],
+  testMatch: [
+    "<rootDir>/tests/synthetic/runner.test.ts",
+    "<rootDir>/tests/synthetic/calibration.test.ts",
+  ],
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { tsconfig: { module: "commonjs" } }],
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:ai": "jest --config jest.ai.config.ts --verbose",
+    "test:ai": "jest --config jest.ai.config.ts --verbose runner.test.ts",
+    "test:ai:calibration": "jest --config jest.ai.config.ts calibration.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/tests/synthetic/README.md
+++ b/tests/synthetic/README.md
@@ -1,0 +1,166 @@
+# Synthetic eval — drift + calibration
+
+Two-layer eval system over the 8 synthetic SR 11-7 documents in `tests/synthetic/documents/`.
+
+| Layer | Asks | Source of truth | When it runs |
+|-------|------|-----------------|--------------|
+| **Drift** (`runner.test.ts`) | "Did we break it?" | `baseline.json` — final + per-pillar scores from a previous run | Every PR via `.github/workflows/pr.yml` |
+| **Calibration** (`calibration.test.ts`) | "Is it right?" | `golden_labels.json` — per-element ground-truth labels reviewed by a human | On demand once labels are promoted |
+
+Drift catches regressions. Calibration measures whether the production agents actually detect the gaps a competent SR 11-7 reviewer would expect.
+
+---
+
+## ⚠ Drafted labels are not ground truth
+
+`golden_labels.draft.json` was machine-drafted during the harness build, not authored by a human reviewer. **It must be human-reviewed before promotion.** The harness reads `golden_labels.json` (no `.draft` suffix), so the draft file cannot accidentally become a CI gate.
+
+When reviewing, prioritize labels with `"ambiguous": true` — those are the cases where a competent reviewer might disagree with the drafted call.
+
+---
+
+## Promotion workflow
+
+1. Read through `golden_labels.draft.json`. Adjust labels against the underlying document content.
+2. Pay particular attention to entries where `ambiguous: true`.
+3. When labels are trusted as ground truth, rename:
+
+   ```bash
+   mv tests/synthetic/golden_labels.draft.json tests/synthetic/golden_labels.json
+   ```
+
+4. The calibration test now activates. Run it:
+
+   ```bash
+   ANTHROPIC_API_KEY=sk-... npm run test:ai:calibration
+   ```
+
+5. The harness writes `tests/synthetic/calibration-report.json` with per-element recall, precision, and severity-agreement.
+
+There is intentionally no automated promotion path. The rename is the human sign-off.
+
+---
+
+## How to run
+
+```bash
+# Drift test — compares scores against baseline.json (~2 min)
+ANTHROPIC_API_KEY=sk-... npm run test:ai
+
+# Calibration test — per-element accuracy against promoted labels (~3-5 min)
+ANTHROPIC_API_KEY=sk-... npm run test:ai:calibration
+```
+
+The drift test runs in CI. Calibration runs on demand only — even after labels are promoted, it is not automatically wired into `pr.yml`. Add it there explicitly when you decide it should gate merges.
+
+If `golden_labels.json` does not exist, calibration **skips gracefully** with a console warning. It never fails CI.
+
+---
+
+## Calibration metrics
+
+For each `(pillar, element_id)` aggregated across all promoted docs:
+
+- **Recall** = `must_detect=true` labels caught by the agent / total `must_detect=true` labels.
+- **Precision** = agent flags that match a `weak`/`missing` label / total agent flags for this element.
+- **Severity agreement** = matched gaps where agent severity (`Critical`/`Major`/`Minor`) matches `expected_severity` / total matched gaps with a labeled severity.
+
+Aggregates are also computed per pillar and overall.
+
+### Pass/fail thresholds
+
+| Recall | Outcome |
+|--------|---------|
+| ≥ 0.85 | Pass silently |
+| 0.70 – 0.85 | Watchlist warning (test passes; surfaced in console + report) |
+| < 0.70 | **Fail** |
+
+These thresholds apply only to `(pillar, element_id)` pairs with at least one `must_detect=true` label.
+
+---
+
+## Label file shape
+
+```json
+[
+  {
+    "doc_id": "test_cecl_compliant",
+    "model_type": "allowance_cecl_cre",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "present | weak | missing | not_applicable",
+        "expected_severity": "critical | major | minor | null",
+        "must_detect": true | false,
+        "rationale": "Why this label, grounded in the document.",
+        "ambiguous": true | false
+      }
+    ]
+  }
+]
+```
+
+- `expected_severity` is `null` when `expected_status` is `present` or `not_applicable`.
+- `must_detect=true` means a competent reviewer would expect the agent to surface this gap. Reserve it for clear cases.
+- The agent emits severity as `Critical`/`Major`/`Minor`; labels use lowercase `critical`/`major`/`minor`. The harness compares case-insensitively.
+
+The harness does not consume `model_type` for execution — it is informational metadata for human reviewers grouping similar documents.
+
+---
+
+## Element ID mapping
+
+The label file uses zero-padded element IDs (`CS-01`, not `CS-1`) to match `ElementCodeEnum` in `src/lib/validation/schemas.ts` and the prompts in `docs/AGENT_PROMPTS.md`.
+
+### Conceptual Soundness (CS) — pillar weight 40%
+
+| ID | Element |
+|----|---------|
+| CS-01 | Model Purpose and Intended Use |
+| CS-02 | Theoretical and Mathematical Framework |
+| CS-03 | Key Assumptions Documentation |
+| CS-04 | Assumption Limitations and Boundaries |
+| CS-05 | Data Inputs and Sources |
+| CS-06 | Model Scope and Applicability |
+| CS-07 | Known Model Weaknesses |
+
+### Outcomes Analysis (OA) — pillar weight 35%
+
+| ID | Element |
+|----|---------|
+| OA-01 | Backtesting Methodology |
+| OA-02 | Performance Metrics Definition and Reporting |
+| OA-03 | Benchmarking Against Alternative Models |
+| OA-04 | Sensitivity Analysis |
+| OA-05 | Stress Testing |
+| OA-06 | Out-of-Sample Testing |
+| OA-07 | Statistical Validation Results |
+
+### Ongoing Monitoring (OM) — pillar weight 25%
+
+| ID | Element |
+|----|---------|
+| OM-01 | KPIs and Performance Thresholds |
+| OM-02 | Monitoring Frequency |
+| OM-03 | Escalation Procedures |
+| OM-04 | Trigger Conditions for Model Review |
+| OM-05 | Data Quality Monitoring |
+| OM-06 | Change Management Process |
+
+---
+
+## Files
+
+```
+tests/synthetic/
+├── README.md                       — this file
+├── runner.test.ts                  — drift suite (unchanged)
+├── calibration.test.ts             — calibration suite (this addition)
+├── baseline.json                   — drift reference scores
+├── golden_labels.draft.json        — drafted, not yet trusted
+├── golden_labels.json              — promoted labels (created by manual rename)
+├── calibration-report.json         — written by calibration suite each run
+└── documents/                      — 8 synthetic test documents
+```

--- a/tests/synthetic/calibration.test.ts
+++ b/tests/synthetic/calibration.test.ts
@@ -1,0 +1,477 @@
+import * as fs from "fs";
+import * as path from "path";
+import { runCompliance } from "@/lib/agents/orchestrator";
+import type { AgentOutput, Gap } from "@/lib/validation/schemas";
+
+jest.setTimeout(180_000);
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DOCS_DIR = path.join(__dirname, "documents");
+const LABELS_PATH = path.join(__dirname, "golden_labels.json");
+const REPORT_PATH = path.join(__dirname, "calibration-report.json");
+
+const RECALL_FAIL_THRESHOLD = 0.7;
+const RECALL_WATCHLIST_THRESHOLD = 0.85;
+
+type Pillar = AgentOutput["pillar"];
+type SeverityLower = "critical" | "major" | "minor";
+type ExpectedStatus = "present" | "weak" | "missing" | "not_applicable";
+
+// ─── Label / report types (test-only; not API-boundary, not in schemas.ts) ───
+
+interface GoldenLabel {
+  pillar: Pillar;
+  element_id: string;
+  element_name: string;
+  expected_status: ExpectedStatus;
+  expected_severity: SeverityLower | null;
+  must_detect: boolean;
+  rationale: string;
+  ambiguous: boolean;
+}
+
+interface DocLabels {
+  doc_id: string;
+  model_type: string;
+  elements: GoldenLabel[];
+}
+
+interface ElementMetric {
+  pillar: Pillar;
+  element_id: string;
+  must_detect_total: number;
+  must_detect_caught: number;
+  recall: number | null;
+  agent_flags_total: number;
+  agent_flags_matching_label: number;
+  precision: number | null;
+  matched_with_severity: number;
+  severity_agreements: number;
+  severity_agreement: number | null;
+  watchlist: boolean;
+}
+
+interface PillarMetric {
+  pillar: Pillar;
+  recall: number | null;
+  precision: number | null;
+  severity_agreement: number | null;
+}
+
+interface PerDocOutcome {
+  doc_id: string;
+  model_name: string;
+  matched: number;
+  agent_gap_count: number;
+  label_must_detect_count: number;
+  recall_on_doc: number | null;
+}
+
+interface CalibrationReport {
+  generated_at: string;
+  doc_count: number;
+  thresholds: {
+    recall_fail: number;
+    recall_watchlist: number;
+  };
+  per_element: ElementMetric[];
+  per_pillar: PillarMetric[];
+  overall: {
+    recall: number | null;
+    precision: number | null;
+    severity_agreement: number | null;
+  };
+  per_doc: PerDocOutcome[];
+}
+
+// ─── Hardcoded doc -> agent model name (mirrors runner.test.ts) ──────────────
+
+const MODEL_NAMES: Record<string, string> = {
+  test_fully_compliant: "Black-Scholes Option Pricing Model",
+  test_missing_conceptual: "Credit Risk Scorecard Model",
+  test_missing_outcomes: "Mortgage Prepayment Model",
+  test_missing_monitoring: "Interest Rate Swap Valuation Model",
+  test_all_critical_gaps: "Internal Prediction Model",
+  test_prompt_injection: "GARCH Volatility Forecasting Model",
+  test_verbose_low_quality: "ML Credit Risk Model",
+  test_cecl_compliant: "CECL Commercial Real Estate Loan Loss Model",
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function labelsExist(): boolean {
+  return fs.existsSync(LABELS_PATH);
+}
+
+function readLabels(): DocLabels[] {
+  return JSON.parse(fs.readFileSync(LABELS_PATH, "utf-8")) as DocLabels[];
+}
+
+function labelMustBeFlagged(label: GoldenLabel): boolean {
+  return (
+    label.expected_status === "missing" || label.expected_status === "weak"
+  );
+}
+
+function gapsForPillar(output: AgentOutput): Gap[] {
+  return output.gaps;
+}
+
+function safeRatio(num: number, denom: number): number | null {
+  return denom === 0 ? null : num / denom;
+}
+
+function severityMatches(
+  agentSeverity: Gap["severity"],
+  expected: SeverityLower | null
+): boolean {
+  if (!expected) return false;
+  return agentSeverity.toLowerCase() === expected;
+}
+
+// ─── Skip orchestration ──────────────────────────────────────────────────────
+
+const hasLabels = labelsExist();
+const hasApiKey = Boolean(process.env.ANTHROPIC_API_KEY);
+
+if (!hasLabels) {
+  console.warn(
+    "\n⚠  Calibration labels not yet promoted — see tests/synthetic/README.md\n" +
+      "   The harness reads tests/synthetic/golden_labels.json (no .draft suffix).\n" +
+      "   Review tests/synthetic/golden_labels.draft.json, then rename to activate.\n"
+  );
+}
+
+if (hasLabels && !hasApiKey) {
+  console.warn(
+    "\n⚠  ANTHROPIC_API_KEY is not set. Skipping calibration tests.\n" +
+      "   Set the env var to run: ANTHROPIC_API_KEY=sk-... npm run test:ai:calibration\n"
+  );
+}
+
+const shouldRun = hasLabels && hasApiKey;
+const describeOrSkip = shouldRun ? describe : describe.skip;
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+// Jest requires at least one test in a file. When the suite is skipped, this
+// placeholder satisfies that constraint and gives the skip a visible name.
+if (!shouldRun) {
+  describe("Calibration Suite (skipped)", () => {
+    it.skip(
+      hasLabels
+        ? "no ANTHROPIC_API_KEY"
+        : "golden_labels.json not promoted — see tests/synthetic/README.md",
+      () => undefined
+    );
+  });
+}
+
+describeOrSkip("Calibration Suite", () => {
+  const labels: DocLabels[] = shouldRun ? readLabels() : [];
+  // Per-doc agent results, populated by per-doc tests in afterAll aggregation.
+  const agentResults = new Map<string, AgentOutput[]>();
+
+  afterAll(() => {
+    if (!shouldRun) return;
+
+    // ── Aggregation: walk all (doc, label) and (doc, agent_gap) pairs ─────
+
+    type ElementKey = string; // `${pillar}::${element_id}`
+    const elementBucket = new Map<
+      ElementKey,
+      {
+        pillar: Pillar;
+        element_id: string;
+        must_detect_total: number;
+        must_detect_caught: number;
+        agent_flags_total: number;
+        agent_flags_matching_label: number;
+        matched_with_severity: number;
+        severity_agreements: number;
+      }
+    >();
+
+    function bucketFor(pillar: Pillar, elementId: string) {
+      const key = `${pillar}::${elementId}`;
+      let b = elementBucket.get(key);
+      if (!b) {
+        b = {
+          pillar,
+          element_id: elementId,
+          must_detect_total: 0,
+          must_detect_caught: 0,
+          agent_flags_total: 0,
+          agent_flags_matching_label: 0,
+          matched_with_severity: 0,
+          severity_agreements: 0,
+        };
+        elementBucket.set(key, b);
+      }
+      return b;
+    }
+
+    const perDoc: PerDocOutcome[] = [];
+
+    for (const docLabels of labels) {
+      const outputs = agentResults.get(docLabels.doc_id);
+      if (!outputs) continue;
+
+      // Index labels by (pillar, element_id) for this doc.
+      const labelIndex = new Map<string, GoldenLabel>();
+      for (const l of docLabels.elements) {
+        labelIndex.set(`${l.pillar}::${l.element_id}`, l);
+      }
+
+      // Index agent gaps by (pillar, element_code) for this doc — agent may
+      // emit only one gap per element per pillar in practice, but if multiple
+      // appear we count the first match for severity but each as a flag.
+      const flatAgentGaps: Array<{ pillar: Pillar; gap: Gap }> = [];
+      for (const out of outputs) {
+        for (const g of gapsForPillar(out)) {
+          flatAgentGaps.push({ pillar: out.pillar, gap: g });
+        }
+      }
+
+      let docMustDetectTotal = 0;
+      let docMustDetectCaught = 0;
+      let docMatched = 0;
+
+      // Recall pass: walk labels.
+      for (const label of docLabels.elements) {
+        const agentMatched = flatAgentGaps.find(
+          (x) =>
+            x.pillar === label.pillar && x.gap.element_code === label.element_id
+        );
+
+        const bucket = bucketFor(label.pillar, label.element_id);
+
+        if (label.must_detect) {
+          bucket.must_detect_total += 1;
+          docMustDetectTotal += 1;
+          if (agentMatched) {
+            bucket.must_detect_caught += 1;
+            docMustDetectCaught += 1;
+          }
+        }
+
+        // Severity agreement is meaningful only when there is a matched gap
+        // AND the label expects a severity.
+        if (agentMatched && labelMustBeFlagged(label)) {
+          docMatched += 1;
+          bucket.matched_with_severity += 1;
+          if (severityMatches(agentMatched.gap.severity, label.expected_severity)) {
+            bucket.severity_agreements += 1;
+          }
+        }
+      }
+
+      // Precision pass: walk all agent gaps for this doc.
+      for (const { pillar, gap } of flatAgentGaps) {
+        const bucket = bucketFor(pillar, gap.element_code);
+        bucket.agent_flags_total += 1;
+        const label = labelIndex.get(`${pillar}::${gap.element_code}`);
+        if (label && labelMustBeFlagged(label)) {
+          bucket.agent_flags_matching_label += 1;
+        }
+      }
+
+      perDoc.push({
+        doc_id: docLabels.doc_id,
+        model_name: MODEL_NAMES[docLabels.doc_id] ?? docLabels.doc_id,
+        matched: docMatched,
+        agent_gap_count: flatAgentGaps.length,
+        label_must_detect_count: docMustDetectTotal,
+        recall_on_doc: safeRatio(docMustDetectCaught, docMustDetectTotal),
+      });
+    }
+
+    // ── Build per-element metrics ─────────────────────────────────────────
+
+    const perElement: ElementMetric[] = [];
+    for (const b of elementBucket.values()) {
+      const recall = safeRatio(b.must_detect_caught, b.must_detect_total);
+      const precision = safeRatio(
+        b.agent_flags_matching_label,
+        b.agent_flags_total
+      );
+      const sevAgree = safeRatio(b.severity_agreements, b.matched_with_severity);
+      const watchlist =
+        recall !== null &&
+        recall >= RECALL_FAIL_THRESHOLD &&
+        recall < RECALL_WATCHLIST_THRESHOLD &&
+        b.must_detect_total > 0;
+
+      perElement.push({
+        pillar: b.pillar,
+        element_id: b.element_id,
+        must_detect_total: b.must_detect_total,
+        must_detect_caught: b.must_detect_caught,
+        recall,
+        agent_flags_total: b.agent_flags_total,
+        agent_flags_matching_label: b.agent_flags_matching_label,
+        precision,
+        matched_with_severity: b.matched_with_severity,
+        severity_agreements: b.severity_agreements,
+        severity_agreement: sevAgree,
+        watchlist,
+      });
+    }
+
+    perElement.sort((a, b) =>
+      a.pillar === b.pillar
+        ? a.element_id.localeCompare(b.element_id)
+        : a.pillar.localeCompare(b.pillar)
+    );
+
+    // ── Per-pillar and overall aggregates ─────────────────────────────────
+
+    function aggregate(elements: ElementMetric[]) {
+      let mdTotal = 0;
+      let mdCaught = 0;
+      let flagsTotal = 0;
+      let flagsMatching = 0;
+      let sevTotal = 0;
+      let sevAgree = 0;
+      for (const e of elements) {
+        mdTotal += e.must_detect_total;
+        mdCaught += e.must_detect_caught;
+        flagsTotal += e.agent_flags_total;
+        flagsMatching += e.agent_flags_matching_label;
+        sevTotal += e.matched_with_severity;
+        sevAgree += e.severity_agreements;
+      }
+      return {
+        recall: safeRatio(mdCaught, mdTotal),
+        precision: safeRatio(flagsMatching, flagsTotal),
+        severity_agreement: safeRatio(sevAgree, sevTotal),
+      };
+    }
+
+    const pillars: Pillar[] = [
+      "conceptual_soundness",
+      "outcomes_analysis",
+      "ongoing_monitoring",
+    ];
+    const perPillar: PillarMetric[] = pillars.map((pillar) => ({
+      pillar,
+      ...aggregate(perElement.filter((e) => e.pillar === pillar)),
+    }));
+
+    const overall = aggregate(perElement);
+
+    const report: CalibrationReport = {
+      generated_at: new Date().toISOString(),
+      doc_count: perDoc.length,
+      thresholds: {
+        recall_fail: RECALL_FAIL_THRESHOLD,
+        recall_watchlist: RECALL_WATCHLIST_THRESHOLD,
+      },
+      per_element: perElement,
+      per_pillar: perPillar,
+      overall,
+      per_doc: perDoc,
+    };
+
+    fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2) + "\n");
+
+    // ── Console summary ──────────────────────────────────────────────────
+
+    console.log("\n" + "=".repeat(78));
+    console.log("CALIBRATION REPORT");
+    console.log("=".repeat(78));
+    console.log(
+      `Docs evaluated: ${report.doc_count}   |   Report: ${path.relative(
+        process.cwd(),
+        REPORT_PATH
+      )}`
+    );
+
+    const fmt = (v: number | null) => (v === null ? "  n/a" : v.toFixed(2));
+
+    console.log("\nPer-pillar:");
+    for (const p of perPillar) {
+      console.log(
+        `  ${p.pillar.padEnd(24)} recall=${fmt(p.recall)}  precision=${fmt(
+          p.precision
+        )}  severity_agree=${fmt(p.severity_agreement)}`
+      );
+    }
+    console.log(
+      `\nOverall:                  recall=${fmt(overall.recall)}  precision=${fmt(
+        overall.precision
+      )}  severity_agree=${fmt(overall.severity_agreement)}`
+    );
+
+    // ── Watchlist + failure surfacing ─────────────────────────────────────
+
+    const watchlistEls = perElement.filter((e) => e.watchlist);
+    const failingEls = perElement.filter(
+      (e) =>
+        e.must_detect_total > 0 &&
+        e.recall !== null &&
+        e.recall < RECALL_FAIL_THRESHOLD
+    );
+
+    if (watchlistEls.length > 0) {
+      console.log("\n⚠  Watchlist (recall in [0.70, 0.85)):");
+      for (const e of watchlistEls) {
+        console.log(
+          `   ${e.pillar} ${e.element_id} — recall=${(
+            e.recall as number
+          ).toFixed(2)} (${e.must_detect_caught}/${e.must_detect_total})`
+        );
+      }
+    }
+
+    if (failingEls.length > 0) {
+      console.error("\n❌ Calibration failures (recall < 0.70):");
+      for (const e of failingEls) {
+        console.error(
+          `   ${e.pillar} ${e.element_id} — recall=${(
+            e.recall as number
+          ).toFixed(2)} (${e.must_detect_caught}/${e.must_detect_total})`
+        );
+      }
+      throw new Error(
+        `${failingEls.length} element(s) below recall threshold ${RECALL_FAIL_THRESHOLD}. See ${path.relative(
+          process.cwd(),
+          REPORT_PATH
+        )}.`
+      );
+    }
+
+    console.log(
+      `\n✅ All elements with must_detect=true labels meet recall ≥ ${RECALL_FAIL_THRESHOLD}.\n`
+    );
+  });
+
+  // ── Per-doc tests: run pipeline once, store outputs ────────────────────
+  // Guarded because Jest's describe.each rejects an empty input array.
+
+  if (labels.length > 0) {
+    describe.each(labels)("$doc_id", (docLabels: DocLabels) => {
+      it("runs production pipeline and records agent outputs", async () => {
+        const docPath = path.join(DOCS_DIR, `${docLabels.doc_id}.txt`);
+        const documentText = fs.readFileSync(docPath, "utf-8");
+        const modelName = MODEL_NAMES[docLabels.doc_id];
+        if (!modelName) {
+          throw new Error(
+            `No model name mapping for doc_id="${docLabels.doc_id}". Update MODEL_NAMES in calibration.test.ts.`
+          );
+        }
+
+        const { csOutput, oaOutput, omOutput } = await runCompliance(
+          documentText,
+          modelName
+        );
+        agentResults.set(docLabels.doc_id, [csOutput, oaOutput, omOutput]);
+
+        expect(csOutput.pillar).toBe("conceptual_soundness");
+        expect(oaOutput.pillar).toBe("outcomes_analysis");
+        expect(omOutput.pillar).toBe("ongoing_monitoring");
+      });
+    });
+  }
+});

--- a/tests/synthetic/golden_labels.draft.json
+++ b/tests/synthetic/golden_labels.draft.json
@@ -1,0 +1,1650 @@
+[
+  {
+    "doc_id": "test_fully_compliant",
+    "model_type": "options_pricing_black_scholes",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 explicitly states intended use, business decisions supported, scope of appropriate use, and an itemized list of must-not-be-used-for cases.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-02",
+        "element_name": "Theoretical and Mathematical Framework",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 2 derives the BSM PDE, gives closed-form call/put formulas with d1/d2, lists analytical Greeks, and cites the numerical CDF approximation.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-03",
+        "element_name": "Key Assumptions Documentation",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 3 names and explains seven assumptions (log-normal returns, constant volatility, no dividends, frictionless markets, continuous trading, constant rate, no arbitrage).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-04",
+        "element_name": "Assumption Limitations and Boundaries",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 4 maps each assumption to its breakdown conditions with quantitative thresholds (e.g., strikes >15% from spot, bid-ask >5%).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-05",
+        "element_name": "Data Inputs and Sources",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 names every input (S, K, T, sigma, r, q), source vendor (Bloomberg, OPRA, Treasury curve), and explicit data quality / staleness rules.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-06",
+        "element_name": "Model Scope and Applicability",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 6 defines numeric applicability boundaries (moneyness 70-130%, maturity 1d-2y, ADV >500k) and lists explicit not-appropriate-for cases.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-07",
+        "element_name": "Known Model Weaknesses",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 7 proactively discloses five named weaknesses with quantitative impact (e.g., tail-risk underestimated 2.7x, dividend errors >2% premium).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-01",
+        "element_name": "Backtesting Methodology",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 8 specifies a 3-year rolling window (Jan 2022-Dec 2024, 756 days), daily frequency, three measured dimensions, and reporting cadence.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-02",
+        "element_name": "Performance Metrics Definition and Reporting",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 9 defines six metrics (RMSE, MAE, hit rate, hedge effectiveness ratio, VaR exception rate, ADF on residuals) and reports concrete values for each.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-03",
+        "element_name": "Benchmarking Against Alternative Models",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 10 benchmarks against SABR (RMSE 0.019 vs 0.023) and a historical-vol model (0.041), with quantitative comparisons.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-04",
+        "element_name": "Sensitivity Analysis",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 11 quantitatively shocks volatility, rates, spot, and time and reports resulting price changes for an ATM call.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-05",
+        "element_name": "Stress Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 12 defines and reports results for three named stress scenarios (2008 crisis, 2010 flash crash, 80% vol spike).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-06",
+        "element_name": "Out-of-Sample Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 13 documents a 5-year training / 12-month hold-out split with explicit RMSE, MAE, hit-rate, and VaR exception comparisons.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-07",
+        "element_name": "Statistical Validation Results",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 14 reports Kupiec POF, Christoffersen independence and conditional coverage, Jarque-Bera, Ljung-Box, and Durbin-Watson with test statistics and p-values.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-01",
+        "element_name": "KPIs and Performance Thresholds",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 15 lists five named KPIs with explicit numeric thresholds, current values, and breach actions.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-02",
+        "element_name": "Monitoring Frequency",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 16 specifies daily, weekly, monthly, quarterly, and annual activities with named tasks at each frequency.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-03",
+        "element_name": "Escalation Procedures",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 17 defines four escalation levels with specific roles, timelines (1 hour, 24 hours, 5 business days), and audit-trail logging in ServiceNow.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-04",
+        "element_name": "Trigger Conditions for Model Review",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 18 enumerates seven specific quantitative and event-based triggers for model review.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-05",
+        "element_name": "Data Quality Monitoring",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 19 details completeness, timeliness (specific staleness windows), outlier (5-sigma), consistency, and historical integrity controls.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-06",
+        "element_name": "Change Management Process",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 20 defines a six-step change process with classification tiers, parallel-run windows, validation sign-off, and emergency procedures.",
+        "ambiguous": false
+      }
+    ]
+  },
+  {
+    "doc_id": "test_missing_conceptual",
+    "model_type": "credit_scorecard",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "Document has no Conceptual Soundness section; model purpose and intended use are never stated.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-02",
+        "element_name": "Theoretical and Mathematical Framework",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No theoretical or mathematical framework is documented. Logistic regression and scorecard methodology are referenced only in passing within OA sections.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-03",
+        "element_name": "Key Assumptions Documentation",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No assumptions are listed or explained anywhere in the document.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-04",
+        "element_name": "Assumption Limitations and Boundaries",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No limitations or boundary conditions for assumptions are discussed (the doc has no assumptions to bound).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-05",
+        "element_name": "Data Inputs and Sources",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "Although input variables (DTI, FICO, etc.) are referenced in OA sections, the document never documents data inputs and sources as a CS element.",
+        "ambiguous": true
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-06",
+        "element_name": "Model Scope and Applicability",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "Scope is implied through portfolio mentions (retail credit exposures) but never formally documented as approved/not-approved use cases.",
+        "ambiguous": true
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-07",
+        "element_name": "Known Model Weaknesses",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No proactive disclosure of known weaknesses or failure modes.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-01",
+        "element_name": "Backtesting Methodology",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 (Backtesting Methodology) specifies a 5-year rolling window 2019-2024, quarterly frequency, 12-month forward window, and the three evaluation dimensions.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-02",
+        "element_name": "Performance Metrics Definition and Reporting",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 2 defines and reports values for Gini (0.72), KS (0.48), PSI (0.08), Hosmer-Lemeshow chi-sq + p-value, Accuracy Ratio, and default rate by score band.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-03",
+        "element_name": "Benchmarking Against Alternative Models",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 3 benchmarks against logistic regression (0.69), FICO (0.65), and Random Forest (0.76) with explicit Gini comparisons.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-04",
+        "element_name": "Sensitivity Analysis",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 4 quantitatively reports PD changes for DTI, payment history, utilization, credit history, and inquiries, plus a cross-variable interaction.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-05",
+        "element_name": "Stress Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 defines baseline, adverse, severely adverse, and reverse stress scenarios with reported PD and loss outcomes for each.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-06",
+        "element_name": "Out-of-Sample Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 6 documents a temporal hold-out (2015-2021 dev / 2022-2024 test) and geographic hold-out (5 states), with Gini, KS, PSI, calibration p-value reported.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-07",
+        "element_name": "Statistical Validation Results",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 7 reports binomial test, chi-squared goodness-of-fit, Spearman rank correlation, likelihood ratio test, and VIF with statistics and p-values.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-01",
+        "element_name": "KPIs and Performance Thresholds",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Five named KPIs with explicit thresholds (Gini >0.60, PSI <0.25, etc.), current values, and tiered breach actions.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-02",
+        "element_name": "Monitoring Frequency",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Monthly / quarterly / semi-annually / annually activities are individually enumerated.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-03",
+        "element_name": "Escalation Procedures",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Four escalation tiers with explicit roles, timelines (4 hours, 5 business days, 3 business days, 1 business day), and decision criteria.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-04",
+        "element_name": "Trigger Conditions for Model Review",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Seven enumerated triggers including Gini drop, calibration failure, PSI threshold, regulatory and macro regime triggers.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-05",
+        "element_name": "Data Quality Monitoring",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Completeness, timeliness, accuracy, and outlier detection are documented with specific tolerances (e.g., <0.5% missing, 99.97% completeness).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-06",
+        "element_name": "Change Management Process",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Minor / moderate / material / emergency change tiers with parallel-run requirements (60d, 90d) and approval chains.",
+        "ambiguous": false
+      }
+    ]
+  },
+  {
+    "doc_id": "test_missing_outcomes",
+    "model_type": "mortgage_prepayment",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 specifies prepayment forecasting purpose, three named business uses (IRR, MBS valuation, ALM), and explicit not-to-be-used-for cases.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-02",
+        "element_name": "Theoretical and Mathematical Framework",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 2 specifies a logistic + Cox proportional hazards framework with full equations, covariate list, and estimation method (MLE via R).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-03",
+        "element_name": "Key Assumptions Documentation",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 3 lists six named assumptions with explanations (rational refinancing, observable heterogeneity, stable relationship, HPI patterns, default-prepay independence, proportional hazards).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-04",
+        "element_name": "Assumption Limitations and Boundaries",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 4 maps each assumption to its breakdown conditions (fintech-driven incentive shifts, COVID forbearance, geographic concentration, rate path dependence, extreme rates).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-05",
+        "element_name": "Data Inputs and Sources",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 names every input, source (LOS, Black Knight MSP, Freddie PMMS, FHFA HPI), refresh cadence, and validation rules.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-06",
+        "element_name": "Model Scope and Applicability",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 6 defines loan types (30y/15y FRM conforming), vintage cutoff (>=2010), portfolio scope, and explicit not-applicable cases.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-07",
+        "element_name": "Known Model Weaknesses",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 7 lists five named weaknesses (media effect, burnout heterogeneity, seasonal instability, non-refi prepayments, parameter stability).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-01",
+        "element_name": "Backtesting Methodology",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "Document has no Outcomes Analysis section; backtesting methodology is never described. CPR forecast error is referenced as a KPI in OM-01 but no backtesting framework is documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-02",
+        "element_name": "Performance Metrics Definition and Reporting",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No dedicated performance-metrics section. Metric thresholds (MAPE, AUC, calibration ratio) appear only as forward-looking KPI thresholds in OM-01, not as reported backtested values.",
+        "ambiguous": true
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-03",
+        "element_name": "Benchmarking Against Alternative Models",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No benchmarking against alternative models documented. Quarterly benchmarking 'against dealer prepayment models (JPM, GS)' is mentioned only as a future monitoring activity, not as a current performance comparison.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-04",
+        "element_name": "Sensitivity Analysis",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No sensitivity analysis section. Per AGENT_PROMPTS rule, even a qualitative review-statement is Major; here the element is wholly absent.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-05",
+        "element_name": "Stress Testing",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No stress scenarios defined or stress test results reported.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-06",
+        "element_name": "Out-of-Sample Testing",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No train/test split, hold-out period, or out-of-sample results documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-07",
+        "element_name": "Statistical Validation Results",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No formal statistical tests reported (no Kupiec, Hosmer-Lemeshow, or other test statistics with p-values).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-01",
+        "element_name": "KPIs and Performance Thresholds",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Five named KPIs with explicit numeric thresholds and current values (CPR MAPE <20%, AUC >0.75, calibration ratio 0.85-1.15, parameter stability, PSI <0.25).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-02",
+        "element_name": "Monitoring Frequency",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Monthly / quarterly / semi-annually / annually activities individually enumerated with specific tasks.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-03",
+        "element_name": "Escalation Procedures",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Four escalation levels with specific triggers (MAPE >20%, AUC <0.75) and timelines (5/3 business days).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-04",
+        "element_name": "Trigger Conditions for Model Review",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Eight specific triggers documented including sustained MAPE breach, AUC degradation, PSI threshold, rate-regime change, regulatory change.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-05",
+        "element_name": "Data Quality Monitoring",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Loan-level completeness (99.97%), market data timeliness, monthly reconciliation (0.02% discrepancy), and vintage drift detection all documented with thresholds.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-06",
+        "element_name": "Change Management Process",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Three categories (A/B/C) with parallel-run windows (60d, 90d), independent validation requirements, and emergency procedures.",
+        "ambiguous": false
+      }
+    ]
+  },
+  {
+    "doc_id": "test_missing_monitoring",
+    "model_type": "interest_rate_swap_valuation",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 documents intended use, four named business decisions, approved swap types/currencies/maturities, and explicit not-to-be-used-for cases.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-02",
+        "element_name": "Theoretical and Mathematical Framework",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 2 derives DCF valuation under a multi-curve framework, gives fixed/floating leg formulas, forward rate construction, and bootstrap methodology.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-03",
+        "element_name": "Key Assumptions Documentation",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 3 lists six named assumptions with explanations (no default risk under CSA, deterministic rates, continuous compounding, perfect collateralization, static notional, day-count accuracy).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-04",
+        "element_name": "Assumption Limitations and Boundaries",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 4 quantifies breakdown conditions (1-3bp convexity error on 30y, 0.5-2bp uncertainty for non-CSA portfolio, SOFR transition basis).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-05",
+        "element_name": "Data Inputs and Sources",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 names every input, source (NY Fed SOFR, CME futures, Bloomberg ICAP, Murex, DTCC), validation thresholds, and reconciliation requirements.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-06",
+        "element_name": "Model Scope and Applicability",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 6 defines plain-vanilla scope, currencies (USD/EUR/GBP/JPY), maturities (1m-30y), and explicit not-applicable boundary cases.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-07",
+        "element_name": "Known Model Weaknesses",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 7 lists five named weaknesses (no convexity adjustment, interpolation sensitivity, end-of-day timing, basis risk, calendar maintenance).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-01",
+        "element_name": "Backtesting Methodology",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 (OA) specifies hypothetical-portfolio approach, daily frequency, 3-year window, three measured dimensions, and reporting cadence.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-02",
+        "element_name": "Performance Metrics Definition and Reporting",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 2 (OA) defines and reports five metrics with values: Valuation RMSE 0.42bp, P&L explanation 94.3%, DV01 ratio 0.98, curve fit MAE 0.08bp, bid-ask coverage 97.2%.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-03",
+        "element_name": "Benchmarking Against Alternative Models",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 3 (OA) benchmarks against LCH/CME (0.35bp), Bloomberg SWPM (0.52bp), and QuantLib (0.12bp) with quantitative comparisons.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-04",
+        "element_name": "Sensitivity Analysis",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 4 (OA) reports parallel rate shifts, key rate DV01s by tenor, curve twist, and basis spread sensitivity with quantitative results.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-05",
+        "element_name": "Stress Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 (OA) defines and reports three stress scenarios (2022 hike, 2020 COVID, 2s10s inversion) with portfolio impacts and reverse stress test.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-06",
+        "element_name": "Out-of-Sample Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 6 (OA) documents temporal hold-out (2019-2022 dev / 2023-2024 test) and currency hold-out (EUR) with explicit metric comparisons.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-07",
+        "element_name": "Statistical Validation Results",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 7 (OA) reports residual t-test, Jarque-Bera, Ljung-Box, regression slope, ADF stationarity test, and chi-squared with statistics and p-values.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-01",
+        "element_name": "KPIs and Performance Thresholds",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "Document has no Ongoing Monitoring section; no KPIs or thresholds defined for ongoing monitoring.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-02",
+        "element_name": "Monitoring Frequency",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No monitoring frequency documented anywhere in the document.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-03",
+        "element_name": "Escalation Procedures",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No escalation procedures documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-04",
+        "element_name": "Trigger Conditions for Model Review",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No trigger conditions for model review documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-05",
+        "element_name": "Data Quality Monitoring",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "Data quality requirements appear in CS-05 (Data Inputs and Sources) but no ongoing data quality monitoring framework is defined.",
+        "ambiguous": true
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-06",
+        "element_name": "Change Management Process",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No change management process documented.",
+        "ambiguous": false
+      }
+    ]
+  },
+  {
+    "doc_id": "test_all_critical_gaps",
+    "model_type": "unspecified_minimal",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "Document is a single paragraph. 'Various business purposes' is not a documented intended use; no scope of appropriate use stated.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-02",
+        "element_name": "Theoretical and Mathematical Framework",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "'Advanced techniques' with no equations, methods, or framework name.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-03",
+        "element_name": "Key Assumptions Documentation",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No assumptions listed.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-04",
+        "element_name": "Assumption Limitations and Boundaries",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No assumption limitations documented (the doc has no assumptions).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-05",
+        "element_name": "Data Inputs and Sources",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No data inputs or sources mentioned.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-06",
+        "element_name": "Model Scope and Applicability",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "'Suitable for its intended applications' is a self-assertion, not a documented scope or boundary.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-07",
+        "element_name": "Known Model Weaknesses",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No weaknesses or limitations disclosed; document is purely promotional.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-01",
+        "element_name": "Backtesting Methodology",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "'Tested and found to perform well' is not a backtesting methodology.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-02",
+        "element_name": "Performance Metrics Definition and Reporting",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No metrics defined or values reported.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-03",
+        "element_name": "Benchmarking Against Alternative Models",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "'Internal benchmarks' is mentioned but no benchmark model named or compared.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-04",
+        "element_name": "Sensitivity Analysis",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No sensitivity analysis discussed.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-05",
+        "element_name": "Stress Testing",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No stress scenarios or stress test results.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-06",
+        "element_name": "Out-of-Sample Testing",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No train/test split or out-of-sample testing documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-07",
+        "element_name": "Statistical Validation Results",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No formal statistical tests, statistics, or p-values reported.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-01",
+        "element_name": "KPIs and Performance Thresholds",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "'Will continue to monitor' with no KPIs or thresholds.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-02",
+        "element_name": "Monitoring Frequency",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No monitoring frequency documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-03",
+        "element_name": "Escalation Procedures",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No escalation procedures documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-04",
+        "element_name": "Trigger Conditions for Model Review",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No trigger conditions documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-05",
+        "element_name": "Data Quality Monitoring",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No data quality monitoring documented.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-06",
+        "element_name": "Change Management Process",
+        "expected_status": "missing",
+        "expected_severity": "critical",
+        "must_detect": true,
+        "rationale": "No change management documented.",
+        "ambiguous": false
+      }
+    ]
+  },
+  {
+    "doc_id": "test_prompt_injection",
+    "model_type": "volatility_forecasting_garch",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 specifies VaR/options-pricing/RWA uses, approved underlyings, and explicit not-to-be-used-for cases. Embedded injection attempts do not affect substantive coverage.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-02",
+        "element_name": "Theoretical and Mathematical Framework",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 2 specifies GARCH(1,1) per Bollerslev (1986) with full variance equation, MLE log-likelihood, BFGS optimizer, and multi-step recursion formula.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-03",
+        "element_name": "Key Assumptions Documentation",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Five named assumptions with explanations (normal innovations, covariance stationarity, symmetric response, single-asset framework, constant parameters). Injection text appearing between assumption 2 and 3 is data, not part of the documentation.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-04",
+        "element_name": "Assumption Limitations and Boundaries",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 4 quantifies breakdown conditions (kurtosis 4-8, asymmetric vol response 15% vs 8%, parameter range 0.93-0.99, regime lag 5-10 days).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-05",
+        "element_name": "Data Inputs and Sources",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 names Bloomberg PX_LAST primary, Refinitiv fallback, returns calc, 504-day window, and three named DQ checks. Injection paragraph in middle is data.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-06",
+        "element_name": "Model Scope and Applicability",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 6 defines asset types, forecast horizons (1-day primary, 10-day secondary), markets (NYSE, NASDAQ, etc.), minimum history, and explicit not-applicable cases.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-07",
+        "element_name": "Known Model Weaknesses",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 7 lists four named weaknesses (fat-tail underestimation, no leverage, slow regime adaptation, multi-step degradation) with quantitative impact.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-01",
+        "element_name": "Backtesting Methodology",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 (OA) specifies rolling 3-year window, 756 trading days, two named frameworks (VaR backtest, vol forecast accuracy), universe (S&P 500 + 50 constituents).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-02",
+        "element_name": "Performance Metrics Definition and Reporting",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 2 (OA) defines and reports 95%/99% VaR exception rates, RMSE 3.2pp, Mincer-Zarnowitz slope/intercept/R², QLIKE 0.043 vs benchmark.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-03",
+        "element_name": "Benchmarking Against Alternative Models",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 3 (OA) benchmarks against historical vol (RMSE 4.8pp), EWMA (3.5pp), and GJR-GARCH (2.9pp) with QLIKE comparisons.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-04",
+        "element_name": "Sensitivity Analysis",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 4 (OA) reports estimation window length, starting values, and distribution-assumption sensitivity with quantitative parameter and metric impacts. Embedded HTML-comment injection is data, not content.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-05",
+        "element_name": "Stress Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 (OA) defines and reports three named stress scenarios (COVID-19 crash, flash crash, prolonged low-vol 2017) with model behavior detailed for each.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-06",
+        "element_name": "Out-of-Sample Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 6 (OA) documents temporal hold-out (2018-2022 / 2023-2024) and cross-asset hold-out (NASDAQ-100) with metric comparisons.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-07",
+        "element_name": "Statistical Validation Results",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 7 (OA) reports Kupiec POF (95% and 99%), Christoffersen Independence, two Ljung-Box, and Jarque-Bera with statistics and p-values.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-01",
+        "element_name": "KPIs and Performance Thresholds",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 (OM) lists five named KPIs with explicit numeric thresholds and current values (99% VaR <2.5%, RMSE <4.5pp, persistence 0.90-0.995, etc.).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-02",
+        "element_name": "Monitoring Frequency",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Daily / weekly / monthly / quarterly / annually activities individually enumerated.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-03",
+        "element_name": "Escalation Procedures",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Four escalation levels with explicit triggers, roles, and timelines (2 hours, 24 hours, 3 / 5 business days).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-04",
+        "element_name": "Trigger Conditions for Model Review",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Six named triggers (VaR red zone, sustained RMSE, parameter non-stationarity, market regime change, regulatory change, annual cadence).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-05",
+        "element_name": "Data Quality Monitoring",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 (OM) details price-data completeness, return outlier monitoring, corporate-action handling, and estimation-window integrity.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-06",
+        "element_name": "Change Management Process",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Three change tiers (minor / moderate / material) with parallel-run windows (30d, 90d), independent validation, and emergency procedures.",
+        "ambiguous": false
+      }
+    ]
+  },
+  {
+    "doc_id": "test_verbose_low_quality",
+    "model_type": "ml_credit_risk_generic",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Section 1 lists business decisions categorically ('credit origination, portfolio management, loss forecasting, capital allocation, stress testing') but never specifies what the model does, what decisions it supports concretely, or what it should NOT be used for.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-02",
+        "element_name": "Theoretical and Mathematical Framework",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Mentions 'machine learning', 'ensemble methods', 'feature engineering', 'regularization' as framework names but provides no equations, no specific algorithm, no derivation. Per AGENT_PROMPTS rule, framework name without explanation is Major.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-03",
+        "element_name": "Key Assumptions Documentation",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Section 3 names six generic assumptions (stationarity, representativeness, data quality, environmental, observable variables, regulatory) but explanations are tautological. Not model-specific.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-04",
+        "element_name": "Assumption Limitations and Boundaries",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Discusses limitations in generic terms ('may be violated during economic disruption') without quantitative breakdown thresholds or concrete failure conditions.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-05",
+        "element_name": "Data Inputs and Sources",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Names data source categories ('credit bureau data, public records, economic indicators') but no specific vendors, fields, refresh cadences, or quality requirements. Per AGENT_PROMPTS rule, this is Major.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-06",
+        "element_name": "Model Scope and Applicability",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Applicability described as 'broad scope of credit products and borrower segments' with no specific product list or boundaries. Per AGENT_PROMPTS rule, vague applicability is Major.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-07",
+        "element_name": "Known Model Weaknesses",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Lists generic weaknesses (data dependency, complexity, bias, performance degradation) without quantitative impact or model-specific failure modes.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-01",
+        "element_name": "Backtesting Methodology",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Mentions 'comprehensive backtesting framework' and 'multi-faceted approach' but no specific methodology, period, frequency, or sample. Per AGENT_PROMPTS rule, this is Major.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-02",
+        "element_name": "Performance Metrics Definition and Reporting",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "References 'comprehensive suite of industry-standard metrics' covering 'predictive accuracy, discrimination power, calibration quality' but no specific metrics named (no AUC, KS, RMSE, etc.) and no values reported. Borderline Critical/Major; the section heading exists so we treat as Major.",
+        "ambiguous": true
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-03",
+        "element_name": "Benchmarking Against Alternative Models",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Mentions 'simpler statistical models, alternative ML approaches, and industry-standard vendor solutions' as comparison categories but no specific benchmarks named or results reported.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-04",
+        "element_name": "Sensitivity Analysis",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Sensitivity analysis described qualitatively ('local and global techniques') with no quantitative results. Per AGENT_PROMPTS rule, this is Major.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-05",
+        "element_name": "Stress Testing",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Mentions sensitivity-based and scenario-based stress tests but no specific scenarios defined or results reported.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-06",
+        "element_name": "Out-of-Sample Testing",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Names approaches (temporal hold-out, k-fold CV, segment hold-out) but no specific train/test split, hold-out period, or results.",
+        "ambiguous": true
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-07",
+        "element_name": "Statistical Validation Results",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "References a 'battery of complementary tests' and 'rigorous quantitative techniques' but no specific tests named, no statistics, no p-values. Per AGENT_PROMPTS rule, this is Major.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-01",
+        "element_name": "KPIs and Performance Thresholds",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "References 'comprehensive set of KPIs' covering categorical dimensions but no specific KPIs named and no numeric thresholds. Borderline Critical (per AGENT_PROMPTS rule on vague monitoring) but element heading exists, so Major.",
+        "ambiguous": true
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-02",
+        "element_name": "Monitoring Frequency",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Frequencies described categorically ('high-frequency daily-to-weekly', 'medium-frequency monthly-to-quarterly') without specific schedules or activities pinned to each.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-03",
+        "element_name": "Escalation Procedures",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Mentions 'multiple tiers of response' but no specific people, timelines, or trigger criteria. Per AGENT_PROMPTS rule, vague escalation is Major.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-04",
+        "element_name": "Trigger Conditions for Model Review",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Mentions 'performance-based' and 'event-based' trigger categories but no specific triggers documented (no thresholds, no named events).",
+        "ambiguous": true
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-05",
+        "element_name": "Data Quality Monitoring",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Describes 'automated quality checks' and 'comprehensive reconciliation' framework but no specific checks, tolerances, or completeness rates. Per AGENT_PROMPTS rule, this is Major.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-06",
+        "element_name": "Change Management Process",
+        "expected_status": "weak",
+        "expected_severity": "major",
+        "must_detect": true,
+        "rationale": "Describes change-management 'framework' with risk-tiered governance but no specific procedures, parallel-run windows, or approval roles.",
+        "ambiguous": false
+      }
+    ]
+  },
+  {
+    "doc_id": "test_cecl_compliant",
+    "model_type": "allowance_cecl_cre",
+    "elements": [
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-01",
+        "element_name": "Model Purpose and Intended Use",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 1 specifies CECL ACL purpose under ASC 326-20, five named business decisions, six approved CRE segments, and seven explicit not-to-be-used-for cases.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-02",
+        "element_name": "Theoretical and Mathematical Framework",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 2 derives the PD/LGD/EAD ECL formula and details cloglog hazard PD model, two-stage LGD (multinomial + beta regression), CCF EAD, and prepayment module.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-03",
+        "element_name": "Key Assumptions Documentation",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 3 lists eight named assumptions with explanations (stationarity, homogeneity, conditional independence, representativeness, R&S horizon, prepayment predictability, LGD timing, discount rate).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-04",
+        "element_name": "Assumption Limitations and Boundaries",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 4 maps each assumption to specific breakdown conditions plus four numeric override thresholds (unemployment >10%, CRE PI -40%, default rate >3x, rate move >300bp/12mo).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-05",
+        "element_name": "Data Inputs and Sources",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 5 names every input, source (LoanIQ, CoStar, BLS, RCA CPPI, Fed H.15, ICE BofA, BEA, Moody's), refresh cadence, and validation rules.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-06",
+        "element_name": "Model Scope and Applicability",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 6 specifies 1,847-loan portfolio, six property types with concentrations, geographic distribution, five enumerated boundary conditions.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "conceptual_soundness",
+        "element_id": "CS-07",
+        "element_name": "Known Model Weaknesses",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 7 lists six named weaknesses (sponsor concentration, structural shifts in office, GFC overweight, vintage grouping, climate risk gap, linear reversion).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-01",
+        "element_name": "Backtesting Methodology",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 8 specifies three backtesting methodologies (PD binomial test, LGD MAE/RMSE, ECL coverage) with frequencies, samples, acceptance thresholds, and Q4 2025 results.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-02",
+        "element_name": "Performance Metrics Definition and Reporting",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 9 defines and reports AUC 0.78, KS 0.42, Brier 0.037, Hosmer-Lemeshow chi-sq + p, PSI 0.06, plus LGD MAE/RMSE/R² and ECL coverage with targets and current values.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-03",
+        "element_name": "Benchmarking Against Alternative Models",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 10 benchmarks against vintage loss rate ($378M), Moody's CRE EL ($445M), and Y-14 peer median (2.75% vs institution 2.90%), with quantitative comparisons.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-04",
+        "element_name": "Sensitivity Analysis",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 11 reports a sensitivity table for 10 inputs with ECL impact in dollars and percent, plus identifies the four most material drivers.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-05",
+        "element_name": "Stress Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 12 defines and reports three stress scenarios (mild recession, severe recession, CRE-specific) with stressed ECL and CET1 capital impact.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-06",
+        "element_name": "Out-of-Sample Testing",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 13 documents temporal holdout (12-quarter), 5-fold CV, and external ACLI sample comparison with explicit metric values.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "outcomes_analysis",
+        "element_id": "OA-07",
+        "element_name": "Statistical Validation Results",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 14 reports coefficient SEs and signs for 14 covariates, pseudo-R², LR test, AIC, VIFs, Pregibon link test, and beta-regression dispersion phi.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-01",
+        "element_name": "KPIs and Performance Thresholds",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 15 provides a Green/Amber/Red KPI table with seven named KPIs and explicit thresholds plus rationale for each threshold.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-02",
+        "element_name": "Monitoring Frequency",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 16 enumerates monthly / quarterly / semi-annually / annually / ad-hoc activities with specific tasks at each frequency.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-03",
+        "element_name": "Escalation Procedures",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 17 defines Green->Amber and Amber->Red workflows with named roles, business-day timelines, decision options, and MRMIS audit logging.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-04",
+        "element_name": "Trigger Conditions for Model Review",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 18 enumerates quantitative, environmental, and methodological triggers with explicit thresholds (AUC <0.65, coverage 0.60-2.00, PSI 0.25, etc.).",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-05",
+        "element_name": "Data Quality Monitoring",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 19 details four pipeline stages of automated/manual controls with completeness >99%, outlier thresholds, and lineage/governance.",
+        "ambiguous": false
+      },
+      {
+        "pillar": "ongoing_monitoring",
+        "element_id": "OM-06",
+        "element_name": "Change Management Process",
+        "expected_status": "present",
+        "expected_severity": null,
+        "must_detect": false,
+        "rationale": "Section 20 defines three change tiers with explicit examples, seven-step workflow, MRMIS logging, Git version control, 7-year retention, and immutable audit trail.",
+        "ambiguous": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- Adds a calibration layer alongside the existing drift-detection eval. Drift answers "did we break it?"; calibration answers "is it right?" by comparing the production agents' detected gaps to per-element ground-truth labels for each of the 20 SR 11-7 elements (CS-01..CS-07, OA-01..OA-07, OM-01..OM-06).
- 160 drafted labels (8 docs × 20 elements) at `tests/synthetic/golden_labels.draft.json`. The `.draft` suffix is load-bearing — `calibration.test.ts` reads `golden_labels.json` only, so the draft cannot accidentally become a CI gate. Promotion is a manual rename.
- Per-element recall, precision, and severity agreement are aggregated per pillar and overall, written to `tests/synthetic/calibration-report.json`. Recall < 0.70 fails; 0.70–0.85 is a watchlist warning.
- Calibration runs on demand via `npm run test:ai:calibration`. Drift (`npm run test:ai`) and `pr.yml` are unchanged. The suite skips gracefully when labels are absent or `ANTHROPIC_API_KEY` is unset.

## Files

- `tests/synthetic/golden_labels.draft.json` — drafted labels (not yet ground truth; needs human review)
- `tests/synthetic/calibration.test.ts` — calibration harness
- `tests/synthetic/README.md` — two-layer eval docs, promotion workflow, element ID mapping
- `jest.ai.config.ts` — `testMatch` widened to include calibration
- `package.json` — `test:ai:calibration` script added; `test:ai` filtered to `runner.test.ts` so existing CI behavior is preserved

## Reviewer focus

8 labels are flagged `\"ambiguous\": true` — start there. They are listed in `README.md` and represent borderline calls between Critical/Major or between weak/present where the document is genuinely under-specified.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:ai` (no API key) — drift suite skips gracefully, runner unchanged
- [x] `npm run test:ai:calibration` (no labels) — skips with the documented message, exit clean
- [x] JSON shape validated: 8 docs × 20 elements, severity null iff status is `present` or `not_applicable`
- [x] ESLint clean on the new test file
- [ ] Reviewer walks `golden_labels.draft.json` and edits before promotion
- [ ] After review, `mv tests/synthetic/golden_labels.draft.json tests/synthetic/golden_labels.json` and run `npm run test:ai:calibration` end-to-end against the real API