### PR TITLE
feat(infra): add Vercel daily cron to keep Supabase active

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,4 +1,5 @@
 import { GET } from './route';
+import { NextRequest } from 'next/server';
 
 jest.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
@@ -12,7 +13,7 @@ jest.mock('@supabase/supabase-js', () => ({
 
 describe('GET /api/health', () => {
   it('returns 200 with status ok when database is reachable', async () => {
-    const res = await GET();
+    const res = await GET(new NextRequest('http://localhost/api/health'));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe('ok');

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,6 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
+import { type NextRequest } from "next/server";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
   const timestamp = new Date().toISOString();
   let databaseOk = false;
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/health",
+      "schedule": "0 0 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Adds vercel.json with a daily cron hitting /api/health, and secures that route with an optional CRON_SECRET bearer token check.

## Context
<!-- Why does this change exist? What problem does it solve? Link to issue if applicable. -->


## Logic
<!-- How does it work? Walk through the key decisions made. -->


## Edge Cases
<!-- What could go wrong? What did you test or guard against? -->


## Alternatives Considered
<!-- What other approaches were explored and why were they rejected? -->


## Review Focus
<!-- What should the reviewer pay close attention to? -->


---

## AI Disclosure
| Field | Details |
|-------|---------|
| AI-generated | <!-- e.g. ~80% --> |
| Tool used | <!-- e.g. Claude Code (claude-sonnet-4-6) --> |
| Human review | <!-- What did you manually verify? --> |

## Checklist
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Security reviewed (if touching API routes, agents, or file handling)
