### PR TITLE
fix(db): remove parent_assessment_id remnants that break fresh provisioning

### DIFF
--- a/docs/AGENT_PROMPTS.md
+++ b/docs/AGENT_PROMPTS.md
@@ -447,8 +447,13 @@ claude-haiku-3-5-20241022
 Always use this exact string. Do not use aliases.
 
 ### Token budget per agent
-- Max tokens: 3000 (sufficient for full gap analysis with all 7 elements)
+- Pillar agents (CS / OA / OM): max tokens 3000 — sufficient for full gap
+  analysis across all 7 elements
+- Judge: max tokens 5000 — it returns per-agent feedback for all three pillars
+  in a single response, so it needs more headroom than any one pillar agent
 - Do not increase without testing cost impact
+- Every agent treats `stop_reason === 'max_tokens'` as an error rather than
+  returning a truncated assessment
 
 ---
 

--- a/src/app/(dashboard)/dashboard/benchmarks/page.tsx
+++ b/src/app/(dashboard)/dashboard/benchmarks/page.tsx
@@ -37,7 +37,6 @@ export default async function BenchmarksPage() {
     .select(
       "id, version_number, conceptual_score, outcomes_score, monitoring_score, final_score, assessment_confidence_label, model_type, is_synthetic, created_at, models(model_name)"
     )
-    .is("parent_assessment_id", null)
     .order("created_at", { ascending: false })
     .limit(50);
 

--- a/src/lib/agents/CLAUDE.md
+++ b/src/lib/agents/CLAUDE.md
@@ -15,7 +15,10 @@ Rules for all AI agent code in this folder.
 
 **Model configuration:**
 - Claude model string: `claude-haiku-4-5-20251001` — exact, no aliases
-- Max tokens per agent: 3000
+- Max tokens: 3000 per pillar agent, 5000 for the judge — the judge emits
+  per-agent feedback for all three pillars in one response, so it needs the
+  larger budget. Every agent errors on `stop_reason === 'max_tokens'` rather
+  than returning a truncated assessment.
 - API key only in `src/lib/anthropic/client.ts` — never import or reference it here
 
 **Bias mitigation (never remove from prompts):**

--- a/src/lib/anthropic/CLAUDE.md
+++ b/src/lib/anthropic/CLAUDE.md
@@ -21,7 +21,7 @@ Rules for the Anthropic API client and all LLM call configuration.
 - Do not hardcode the model string in any other file
 
 **Token limits:**
-- Max tokens per agent call: 3000 — enforced at call site in this client
+- Max tokens: 3000 per pillar agent call, 5000 for the judge — enforced at each call site
 - Do not raise this limit without updating `docs/AGENT_ARCHITECTURE.md`
 
 **Error handling:**

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -60,7 +60,7 @@ export type Status = z.infer<typeof StatusEnum>;
 export const ConfidenceLabelEnum = z.enum(["High", "Medium", "Low"]);
 
 // Model type — must stay in lockstep with the public.model_type SQL enum
-// (see supabase/migrations/20260430_model_type_benchmarks.sql).
+// (see supabase/migrations/20260501000000_model_type_benchmarks.sql).
 export const ModelTypeEnum = z.enum([
   "credit_risk_pd_lgd_ead",
   "allowance_cecl_ifrs9",

--- a/supabase/migrations/20260501000000_model_type_benchmarks.sql
+++ b/supabase/migrations/20260501000000_model_type_benchmarks.sql
@@ -85,9 +85,6 @@ BEGIN
     FROM public.submissions s
     WHERE s.model_type = model_type_filter
       AND (include_synthetic OR s.is_synthetic = FALSE)
-      -- Re-assessments share their parent's pillar and are duplicate opinions
-      -- on the same document — exclude them from corpus stats.
-      AND s.parent_assessment_id IS NULL
   ),
   totals AS (
     SELECT
@@ -170,8 +167,7 @@ AS $$
     COUNT(*)::INTEGER                                       AS total_n,
     COUNT(*) FILTER (WHERE is_synthetic = TRUE)::INTEGER    AS synthetic_n,
     COUNT(*) FILTER (WHERE is_synthetic = FALSE)::INTEGER   AS real_n
-  FROM public.submissions
-  WHERE parent_assessment_id IS NULL;
+  FROM public.submissions;
 $$;
 
 REVOKE ALL ON FUNCTION public.get_corpus_disclosure() FROM PUBLIC, anon;


### PR DESCRIPTION
## Context

A fresh database cannot currently be provisioned for this project.

Commit `473ddf3` ("remove disputes/reassessment feature") deleted `supabase/migrations/20260430_dispute_events.sql`. That file was what created `submissions.parent_assessment_id` — but three references to the column outlived it:

| Location | Reference |
|---|---|
| `20260501000000_…sql:90` | `AND s.parent_assessment_id IS NULL` in `get_benchmark_stats` |
| `20260501000000_…sql:174` | `WHERE parent_assessment_id IS NULL` in `get_corpus_disclosure` |
| `dashboard/benchmarks/page.tsx:40` | `.is("parent_assessment_id", null)` |

Build a schema from `docs/DATABASE.md`, apply the remaining migration, and it fails. `get_corpus_disclosure` is `LANGUAGE sql`, whose body Postgres validates at creation time, so the missing column is a hard error at migration time. `get_benchmark_stats` is `plpgsql` — its body isn't semantically checked, so it is created happily and fails later at call time. The deployed database only works because it still carries the column from before the removal.

## Logic

Removed all three references rather than recreating the column.

The predicate meant *"exclude re-assessments from corpus statistics."* With the disputes feature gone, no re-assessment rows can be created, so it filters nothing — it exists purely to break provisioning. Recreating the column would resurrect schema for a deleted feature.

**On editing an applied migration in place.** Migrations are normally immutable once applied, and layering a corrective migration would be the default. That default assumes the original applied successfully somewhere. This one cannot be applied successfully by anyone — keeping it verbatim preserves the defect for every future clone while fixing nobody.

## Edge Cases

- **Deployed vs fresh databases have diverged.** The deleted migration also added `low_confidence_manual_review`, created `dispute_events`, dropped `submissions_model_version_unique`, and replaced it with a *partial* unique index predicated on `parent_assessment_id IS NULL`. Deleting the file undid none of that. A deployed DB therefore has conditional uniqueness on `(model_id, version_number)`; a fresh one gets unconditional. **Nothing references any of it, so behaviour is unchanged** — but reconciling it needs a destructive migration and is deliberately excluded here.
- **No behavioural change to benchmark statistics.** Every row has `parent_assessment_id IS NULL`, so removing the filter cannot alter any aggregate.
- **Verified by static column resolution.** Cross-checked every column the migration touches against the base DDL in `docs/DATABASE.md` plus the migration's own `ADD COLUMN`s — all resolve. Negative control: the same check flags `parent_assessment_id` against the pre-fix file, so it genuinely detects the bug rather than trivially passing.
- **Not verified against a live Postgres** — no local instance available. The failure mode is argued from Postgres's `check_function_bodies` semantics, not observed.

## Alternatives Considered

- **Re-add `parent_assessment_id` via a new migration** — rejected; resurrects schema for a removed feature to satisfy a filter that matches every row.
- **Layer a corrective migration, leave the original** — rejected; the original cannot be applied, so a fresh clone still fails before reaching the correction.
- **Include the destructive cleanup here** — rejected; dropping columns and `dispute_events` is irreversible and belongs in its own reviewable change.
- **Lower judge `max_tokens` to 3000 to match the rule** — rejected; the judge legitimately needs more headroom, so the rule was corrected instead.

## Review Focus

- Confirm you agree the filter is semantically dead — that's the load-bearing assumption.
- The `max_tokens` rule change: `judge.ts:110` uses 5000 while three separate docs mandated a flat 3000. I treated the **rule** as wrong, not the code.
- Whether the deployed/fresh schema divergence should be reconciled in a follow-up.

---

## AI Disclosure
| Field | Details |
|-------|---------|
| AI-generated | ~95% |
| Tool used | Claude Code (claude-opus-5) |
| Human review | Root cause traced to the deleted migration and confirmed before any edit; scope explicitly limited to the non-destructive fix. |

## Checklist
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (288 tests, 18 suites)
- [x] Security reviewed — SECURITY DEFINER functions keep their `REVOKE … FROM PUBLIC, anon` grants and still return aggregates only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
