### PR TITLE
fix: sanitizer corrupting document text, version numbers derived from count

### DIFF
--- a/src/app/api/compliance/route.ts
+++ b/src/app/api/compliance/route.ts
@@ -277,18 +277,32 @@ export async function POST(request: Request) {
     let submission: { id: string; created_at: string; version_number: number } | null = null;
 
     for (let attempt = 0; attempt < MAX_VERSION_RETRIES; attempt++) {
-      const { count, error: countError } = await db
+      // Derive the next version from the highest existing version, not from a
+      // row count. Counting breaks permanently as soon as any submission is
+      // deleted: with v1, v2, v3 present, deleting v2 leaves count = 2, so the
+      // next version is computed as 3 and collides with the surviving v3.
+      // Retrying cannot help, because the count is unchanged — every future
+      // assessment of that model would fail with DATABASE_ERROR.
+      // Deletion is a supported operation, so gaps in the sequence are normal.
+      const { data: latest, error: versionError } = await db
         .from('submissions')
-        .select('id', { count: 'exact', head: true })
+        .select('version_number')
         .eq('model_id', modelId)
-        .eq('user_id', userId);
+        .eq('user_id', userId)
+        .order('version_number', { ascending: false })
+        .limit(1)
+        .maybeSingle();
 
-      if (countError) {
-        Sentry.captureException(countError);
+      if (versionError) {
+        Sentry.captureException(versionError);
         return errorResponse('DATABASE_ERROR');
       }
 
-      const versionNumber = (count ?? 0) + 1;
+      const latestVersion =
+        latest && typeof latest.version_number === 'number'
+          ? latest.version_number
+          : 0;
+      const versionNumber = latestVersion + 1;
 
       const { data: insertedSubmission, error: submissionError } = await db
         .from('submissions')

--- a/src/lib/security/sanitize.test.ts
+++ b/src/lib/security/sanitize.test.ts
@@ -35,6 +35,80 @@ describe("sanitizeText", () => {
     expect(sanitizeText('<img src="x" onerror="alert(1)">')).toBe("");
   });
 
+  // The event-handler and URI-scheme filters were relaxed to stop them
+  // corrupting legitimate prose. These payloads pin down that nothing
+  // dangerous survives as a result — tag removal is what neutralises event
+  // handlers, since they are only meaningful inside a tag.
+  describe("adversarial payloads are neutralised", () => {
+    const payloads = [
+      '<img src=x onerror="alert(1)">',
+      "<img src=x onerror=alert(1)>",
+      "<svg/onload=alert(1)>",
+      '<body onload="alert(1)">',
+      '<a href="javascript:alert(1)">click</a>',
+      '<iframe src="data:text/html,<script>alert(1)</script>"></iframe>',
+      "<scr\x00ipt>alert(1)</scr\x00ipt>",
+      "<SCRIPT>alert(1)</SCRIPT>",
+      "<div onclick='alert(1)'>x</div>",
+      "javascript:alert(1)",
+      "vbscript:MsgBox(1)",
+      "data:text/html;base64,PHNjcmlwdD4=",
+      "<img\nsrc=x\nonerror=alert(1)>",
+    ];
+
+    it.each(payloads)("neutralises %j", (payload) => {
+      const out = sanitizeText(payload);
+      expect(out).not.toMatch(/<\s*script/i);
+      expect(out).not.toMatch(/on(error|load|click)\s*=/i);
+      expect(out).not.toMatch(/javascript\s*:/i);
+      expect(out).not.toMatch(/vbscript\s*:/i);
+      expect(out).not.toMatch(/data\s*:[a-z0-9.+-]*[/,;]/i);
+      expect(out).not.toMatch(/<[a-zA-Z!]/);
+    });
+  });
+
+  // Regression: the event-handler filter was /on\w+\s*=\s*[^\s>]*/gi with no
+  // word boundary, so any word containing "on" followed by word characters and
+  // "=" was destroyed. "monitoring_frequency = daily" sanitized to "m".
+  // Model documentation is largely key = value lines, so this silently
+  // corrupted the text the agents scored.
+  describe("preserves technical model documentation", () => {
+    const cases = [
+      "monitoring_frequency = daily",
+      "confidence_threshold = 0.6",
+      "conversion_rate = 0.05",
+      "long_run = TRUE",
+      "control_group = holdout",
+      "constant_maturity = 10Y",
+      "PD model uses long_run_average = 0.031",
+      "Data: Loan application records from 2019-2024",
+      "Metadata: version 3 of the scorecard",
+      "Data Inputs and Sources: internal origination system",
+    ];
+
+    it.each(cases)("leaves %j unchanged", (input) => {
+      expect(sanitizeText(input)).toBe(input);
+    });
+  });
+
+  // Regression: /<[^>]*>/ spans comparison operators, so a document containing
+  // both "<" and a later ">" lost everything between them.
+  it("preserves inequalities and comparison operators", () => {
+    const text =
+      "Escalate if score < 60 and PD > 0.05 within the monitoring window.";
+    expect(sanitizeText(text)).toBe(text);
+  });
+
+  it("still strips a real tag adjacent to an inequality", () => {
+    expect(sanitizeText("score < 60 <b>bold</b> PD > 0.05")).toBe(
+      "score < 60 bold PD > 0.05"
+    );
+  });
+
+  it("strips an unterminated tag at end of input", () => {
+    expect(sanitizeText("text <img src=x onerror=alert(1)")).toBe("text");
+  });
+
   it("preserves normal plain text prose", () => {
     const prose =
       "The model uses Black-Scholes for option pricing. Assumptions include constant volatility.";

--- a/src/lib/security/sanitize.ts
+++ b/src/lib/security/sanitize.ts
@@ -7,23 +7,36 @@ import { ALLOWED_EXTENSIONS } from "@/lib/validation/schemas";
 export function sanitizeText(raw: string): string {
   let text = raw;
 
-  // Strip null bytes first — they can split keyword patterns to defeat regex filters
+  // Strip null bytes first — they can split keyword patterns to defeat the
+  // filters below (e.g. "<scr\x00ipt>").
   text = text.replace(/\x00/g, "");
 
   // Strip <script>...</script> blocks including their content
   text = text.replace(/<script[\s\S]*?<\/script>/gi, "");
 
-  // Strip dangerous URI schemes
-  text = text.replace(/javascript\s*:/gi, "");
-  text = text.replace(/vbscript\s*:/gi, "");
-  text = text.replace(/data\s*:/gi, "");
+  // Strip HTML tags together with every attribute inside them. This is what
+  // removes event handlers (onerror=, onclick=) and inline URI schemes —
+  // those are only meaningful inside a tag, and the whole tag goes.
+  //
+  // Requiring a tag-like name after "<" matters. A bare /<[^>]*>/ also spans
+  // comparison operators, so "if score < 60 and PD > 0.05" would lose
+  // everything between them. Demanding a letter or "!" leaves arithmetic and
+  // inequalities intact.
+  text = text.replace(/<\/?[a-zA-Z!][^>]*>/g, "");
 
-  // Strip event handler attributes (onerror=, onclick=, etc.)
-  text = text.replace(/on\w+\s*=\s*(['"])[^'"]*\1/gi, "");
-  text = text.replace(/on\w+\s*=\s*[^\s>]*/gi, "");
+  // An unterminated tag at end of input never matches the rule above.
+  text = text.replace(/<\/?[a-zA-Z!][^>]*$/g, "");
 
-  // Strip all remaining HTML tags
-  text = text.replace(/<[^>]*>/g, "");
+  // Strip dangerous URI schemes, but only where they are genuinely a scheme:
+  // at the start of input or after a delimiter, never mid-word. Without the
+  // boundary, "Metadata:" would be treated as a data: URI.
+  text = text.replace(/(^|[\s"'(=,;])(?:javascript|vbscript)\s*:/gi, "$1");
+
+  // data: only when what follows looks like a media type or an immediate
+  // separator. "Data: Loan application records" is a section heading in
+  // virtually every model document — and CS-05 is "Data Inputs and Sources" —
+  // so stripping it would delete the very heading the agent looks for.
+  text = text.replace(/(^|[\s"'(=,;])data\s*:(?=[a-z0-9.+-]*[/,;])/gi, "$1");
 
   // Normalize whitespace
   text = text.replace(/[ \t]+/g, " ");


### PR DESCRIPTION
## Context

Two defects on the compliance critical path. Neither throws. Both produce **wrong results**, which for a compliance scoring product is worse than an outage.

### 1. `sanitizeText()` destroyed legitimate document content

```ts
text.replace(/on\w+\s*=\s*[^\s>]*/gi, "")   // no word boundary before "on"
```

Any word containing "on" followed by word characters and `=` was deleted along with its value. Measured, not theorised:

| Input | Output |
|---|---|
| `monitoring_frequency = daily` | `m` |
| `confidence_threshold = 0.6` | `c` |
| `conversion_rate = 0.05` | `c` |
| `PD model uses long_run = TRUE` | `PD model uses l` |

m**on**itoring, c**on**fidence, c**on**version, l**on**g_run. Model risk documentation is largely `key = value` lines — and "monitoring" names one of the three pillars.

The text was corrupted **before the agents scored it**. Agents then reported gaps that were artifacts of the corruption, which pushes scores *down*, and the corrupted text is what was persisted to `submissions.document_text`. Sanitization also runs before the length check, so a document of mostly assignments could collapse under 100 characters and be rejected as `DOCUMENT_TOO_SHORT`.

Two related false positives fixed alongside:

- **`/data\s*:/gi` removed `"Data:"` anywhere.** That's a section heading in virtually every model document — and **CS-05 is "Data Inputs and Sources"**. The filter deleted the heading the agent looks for, then the agent penalised its absence. Now requires a media type or immediate separator: `data:text/html` is stripped, `Data: Loan records` is not.
- **`/<[^>]*>/` spans comparison operators**, so `if score < 60 and PD > 0.05` lost everything between them. The tag pattern now requires a letter or `!` after `<`.

### 2. Version numbers derived from `COUNT(*)`

```ts
const versionNumber = (count ?? 0) + 1;
```

With a unique constraint on `(model_id, version_number)` and hard deletes supported (`submissions/[id]/route.ts:147`):

> v1, v2, v3 exist. Delete **v2**. Count is now 2 → next version computed as **3** → collides with the surviving v3.

The retry loop cannot recover — it recomputes the same count and the same number, so both attempts fail identically. **Every subsequent assessment of that model returns `DATABASE_ERROR`, permanently.** Deleting any submission that is not the highest version triggers it.

The cost isn't only the failure: the insert runs *after* `runCompliance()`, so four Claude API calls are already spent — and because no row is written, the rate limit isn't consumed, so the user retries and spends again.

## Logic

**Sanitizer:** removed the standalone event-handler patterns entirely. They are redundant — event handlers are only meaningful inside a tag, and tag removal takes the whole tag including every attribute. URI-scheme stripping is now anchored to a delimiter so it cannot fire mid-word (`Metadata:` is safe).

**Versioning:** select the highest existing `version_number` and add one. Gaps in the sequence become harmless, and the retry loop becomes a genuine guard against concurrent inserts rather than a no-op.

## Edge Cases

- **I removed a security control, so I proved the replacement holds.** 13 adversarial payloads are pinned in tests — `<svg/onload=>`, `<img\nsrc=x\nonerror=>`, null-byte-split `<scr\0ipt>`, `data:text/html;base64`, unquoted handlers — asserting no script tag, event handler, dangerous scheme, or tag opener survives.
- **All 7 original security tests still pass unmodified.**
- **Why the bug survived:** both existing "preserves" tests use prose with no assignment or `Data:` pattern. One uses `"Date:"` — a single letter from the input that breaks.
- **Unterminated tags** (`text <img src=x onerror=alert(1)` with no closing `>`) never matched the tag rule; now explicitly handled.
- **Not covered by an integration test:** the versioning fix is argued from the schema constraint and the delete route. There is no test database, so I could not exercise the insert path end to end.

## Alternatives Considered

- **Add `\b` before `on`** — insufficient. `on_time_rate = 0.9` still matches, since `\bon` anchors at a word start. Removing the redundant pattern is both safer and simpler.
- **Scope the filters to tag interiors** — equivalent outcome to removing them, since tag removal already discards interiors, but far more regex.
- **Renumber versions on delete** — rejected; rewrites historical audit records, which is unacceptable in a compliance product. Sparse sequences are the correct model.
- **Move the DB write before the agent calls** so a collision fails fast — a real improvement, but a larger restructure of the route; left for a follow-up.

## Review Focus

- **Confirm you accept dropping the standalone event-handler regexes.** That's the one judgement call. My reasoning: tag removal covers the real vector, this text is never rendered as HTML (React escapes it, `dangerouslySetInnerHTML` is banned, `@react-pdf` doesn't parse HTML), and the false-positive cost was corrupting the product's core input.
- Sparse version numbers now reach the UI. `ScoreProgressionChart` plots score against version — worth a glance to confirm gaps render sensibly.

---

## AI Disclosure
| Field | Details |
|-------|---------|
| AI-generated | ~95% |
| Tool used | Claude Code (claude-opus-5) |
| Human review | Both bugs found by executing the code against realistic input, not by reading it; sanitizer behaviour verified before and after with concrete strings. |

## Checklist
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes — **314 tests**, up from 288 (26 new)
- [x] Security reviewed — sanitizer change is the security-relevant one; 13 adversarial payloads pinned, all 7 original security assertions retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)
