### PR TITLE
docs: correct drift between documentation and implementation (re-target of #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Upload / paste model documentation
 
 ## Features
 
-- **Parallel assessment** — three agents run concurrently via `Promise.all`, judge validates with retry logic (max 2 retries)
+- **Parallel assessment** — three agents run concurrently via `Promise.allSettled`, judge validates with retry logic (max 2 retries)
 - **Weighted scoring** — pillar scores combined into a 0–100 final score with a confidence label
 - **Gap analysis** — every identified gap includes element code, severity, description, and a specific recommendation
 - **PDF reports** — downloadable audit-ready reports generated server-side with `@react-pdf/renderer`
 - **Dashboard** — portfolio view showing score trends, model inventory, and recent submissions
+- **Corpus benchmarks** — compare an assessment against anonymised medians for the same model type, via `SECURITY DEFINER` functions that return aggregates only; suppressed below N=5
+- **Synthetic tagging** — documents can be flagged `is_synthetic` so test corpora never inflate real benchmark statistics
 - **Secure by default** — RLS on all tables, server-side session verification on every API route, files never written to disk
 
 ---
@@ -129,8 +131,15 @@ npm run build         # Type check + production build
 npm run lint          # ESLint
 npm run typecheck     # tsc --noEmit
 npm test              # Jest unit tests
+npm run test:coverage # Jest with coverage (70% threshold)
+npm run test:e2e      # Playwright end-to-end tests
 npm run test:ai       # AI regression suite — run after any agent or scoring change
+npm run test:ai:calibration  # Judge calibration check (real API, costs money)
 ```
+
+`test:ai` and `test:ai:calibration` call the real Claude API. They are not part
+of the PR gate — CI runs them from the `AI Regression` workflow on demand and
+weekly.
 
 ---
 
@@ -161,7 +170,8 @@ prova/
 │   ├── app/
 │   │   ├── (auth)/               # Login, signup pages
 │   │   ├── (dashboard)/          # Protected app pages
-│   │   └── api/                  # compliance · submissions · report · health
+│   │   ├── api/                  # compliance · submissions · report · health · benchmarks
+│   │   └── auth/callback/        # Supabase OAuth code exchange
 │   ├── components/
 │   │   ├── home/                 # Landing page animations
 │   │   └── ...                   # Shared React components
@@ -175,9 +185,8 @@ prova/
 │   │   ├── supabase/             # Browser, server, and middleware clients
 │   │   └── validation/           # All Zod schemas (schemas.ts only)
 │   ├── types/                    # Shared TypeScript types
-│   └── proxy.ts                  # Auth guard for all dashboard routes
+│   └── middleware.ts             # CSRF, session refresh, route guard
 ├── docs/
-│   ├── PRD.md                    # Full product requirements
 │   ├── ARCHITECTURE.md           # System architecture + data flow
 │   ├── DATABASE.md               # Schema, indexes, RLS policies + setup SQL
 │   ├── SCHEMAS.md                # API Zod schema reference
@@ -199,7 +208,6 @@ prova/
 
 | Doc | Contents |
 |---|---|
-| [`docs/PRD.md`](docs/PRD.md) | Full product spec, UI design system, scoring rules |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | System architecture, data flow, agent orchestration |
 | [`docs/DATABASE.md`](docs/DATABASE.md) | Schema, indexes, RLS policies, setup SQL |
 | [`docs/SCHEMAS.md`](docs/SCHEMAS.md) | API request/response Zod schemas |
@@ -207,7 +215,7 @@ prova/
 | [`docs/ERROR_STATES.md`](docs/ERROR_STATES.md) | Error UI behavior and recovery actions |
 | [`src/lib/errors/messages.ts`](src/lib/errors/messages.ts) | Error codes, HTTP statuses, messages (code-level source of truth) |
 
-Focused reference docs (extracted from PRD for efficient lookup):
+Focused reference docs, one per domain:
 
 | Doc | Contents |
 |---|---|

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # Agent Architecture
 
-Extracted from PRD Sections 3.3–3.4, 4, 14.1–14.2, 14.5. This is the focused reference for agent work.
+Focused reference for agent work — agent design, schemas, element codes, and bias mitigation.
 
 ---
 
 ## Parallel Agent Architecture
 
-Three agents run in parallel via `Promise.all`, each owning one SR 11-7 validation pillar:
+Three agents run in parallel via `Promise.allSettled`, each owning one SR 11-7 validation pillar:
 
 | Agent | Pillar | Elements | Weight |
 |-------|--------|----------|--------|
@@ -32,8 +32,16 @@ Runs after three parallel agents complete. Reviews their outputs for:
 - Max 2 retries before accepting output regardless
 - After max retries with confidence still < 0.6 → surface "Low Confidence" warning
 
-**Judge output does NOT affect final compliance score** — separate quality indicator:
-- 0.9–1.0: "High" | 0.7–0.89: "Medium" | 0.5–0.69: "Low" | Below 0.5: "Low" (significant uncertainty)
+**Judge output does NOT affect final compliance score** — separate quality indicator.
+
+`confidence_label` is returned by the judge alongside the numeric `confidence`.
+Nothing derives the label from the number: the orchestrator branches on the
+numeric `confidence` only (`orchestrator.ts`), and the label is validated
+against `ConfidenceLabelEnum` (`High | Medium | Low`) but never cross-checked
+against the score. The bands below are the convention the judge prompt is
+written to, not an invariant the code enforces:
+
+- 0.9–1.0 → High | 0.7–0.89 → Medium | below 0.7 → Low
 
 ---
 

--- a/docs/AGENT_PROMPTS.md
+++ b/docs/AGENT_PROMPTS.md
@@ -112,11 +112,11 @@ You must return ONLY valid JSON matching this exact structure. No preamble, no e
       "element_code": "<CS-01 through CS-07>",
       "element_name": "<full element name>",
       "severity": "<Critical|Major|Minor>",
-      "description": "<specific description of what is missing or incomplete>",
-      "recommendation": "<category-level remediation action>"
+      "description": "<specific description of what is missing or incomplete, max 200 characters>",
+      "recommendation": "<one-sentence remediation action, max 200 characters>"
     }
   ],
-  "summary": "<2-3 sentences summarizing the conceptual soundness assessment>"
+  "summary": "<2-3 sentences summarizing the conceptual soundness assessment, max 500 characters>"
 }
 
 If no gaps are found for an element, do not include it in the gaps array.
@@ -203,11 +203,11 @@ You must return ONLY valid JSON matching this exact structure. No preamble, no e
       "element_code": "<OA-01 through OA-07>",
       "element_name": "<full element name>",
       "severity": "<Critical|Major|Minor>",
-      "description": "<specific description of what is missing or incomplete>",
-      "recommendation": "<category-level remediation action>"
+      "description": "<specific description of what is missing or incomplete, max 200 characters>",
+      "recommendation": "<one-sentence remediation action, max 200 characters>"
     }
   ],
-  "summary": "<2-3 sentences summarizing the outcomes analysis assessment>"
+  "summary": "<2-3 sentences summarizing the outcomes analysis assessment, max 500 characters>"
 }
 
 If no gaps are found for an element, do not include it in the gaps array.
@@ -290,11 +290,11 @@ You must return ONLY valid JSON. No preamble, no explanation, no markdown. Only 
       "element_code": "<OM-01 through OM-06>",
       "element_name": "<full element name>",
       "severity": "<Critical|Major|Minor>",
-      "description": "<specific description of what is missing or incomplete>",
-      "recommendation": "<category-level remediation action>"
+      "description": "<specific description of what is missing or incomplete, max 200 characters>",
+      "recommendation": "<one-sentence remediation action, max 200 characters>"
     }
   ],
-  "summary": "<2-3 sentences summarizing the ongoing monitoring assessment>"
+  "summary": "<2-3 sentences summarizing the ongoing monitoring assessment, max 500 characters>"
 }
 
 If no gaps are found for an element, do not include it in the gaps array.
@@ -361,26 +361,26 @@ CONFIDENCE SCORING RULES:
 - Below 0.5: Significant issues, definitely retry
 
 OUTPUT FORMAT:
-Return ONLY valid JSON. No preamble, no explanation, no markdown.
+Return ONLY valid JSON. No preamble, no explanation, no markdown. Keep your response concise — each issues string must be under 100 characters, max 3 issues per agent.
 
 {
   "confidence": <number 0.0-1.0>,
   "confidence_label": "<High|Medium|Low>",
   "is_consistent": <boolean>,
   "anomaly_detected": <boolean>,
-  "anomaly_description": <string or null>,
+  "anomaly_description": <string max 200 characters, or null>,
   "agent_feedback": {
     "conceptual_soundness": {
       "complete": <boolean>,
-      "issues": [<string array of specific issues found, empty if none>]
+      "issues": [<max 3 strings, each max 100 characters>]
     },
     "outcomes_analysis": {
       "complete": <boolean>,
-      "issues": [<string array of specific issues found, empty if none>]
+      "issues": [<max 3 strings, each max 100 characters>]
     },
     "ongoing_monitoring": {
       "complete": <boolean>,
-      "issues": [<string array of specific issues found, empty if none>]
+      "issues": [<max 3 strings, each max 100 characters>]
     }
   },
   "retry_recommended": <boolean — true if confidence < 0.6>
@@ -418,33 +418,62 @@ The agents have been asked to re-assess with awareness of these issues.
 
 ## Implementation Notes
 
-### How to call agents in `orchestrator.ts`
+### How each agent calls Claude
+
+Each agent module (`src/lib/agents/<pillar>.ts`) builds its own prompt and
+makes its own call. The orchestrator only coordinates them — it does not
+build prompts.
+
 ```typescript
-// Wrap document in XML delimiters before passing to any agent
-const wrappedDocument = `<document>\n${sanitizedText}\n</document>`;
+// The <document> delimiters are already part of USER_PROMPT_TEMPLATE.
+// Do NOT wrap the text again here — that would nest the tags.
+let userPrompt = USER_PROMPT_TEMPLATE;
+userPrompt = userPrompt.split('{modelName}').join(modelName);
+userPrompt = userPrompt.split('{documentText}').join(documentText);
 
-// Build user prompt by replacing template variables
-const userPrompt = AGENT_1_USER_TEMPLATE
-  .replace('{modelName}', modelName)
-  .replace('{documentText}', wrappedDocument);
+if (retryContext) {
+  // appended to the prompt on retry iterations
+}
 
-// Call Claude
-const response = await anthropic.messages.create({
-  model: 'claude-haiku-3-5-20241022',
-  max_tokens: 3000,
-  system: AGENT_1_SYSTEM_PROMPT,
-  messages: [{ role: 'user', content: userPrompt }]
-});
+const response = await anthropic.messages.create(
+  {
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 3000,          // 5000 in judge.ts
+    temperature: 0,            // deterministic scoring
+    system: SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: userPrompt }],
+  },
+  { timeout: 30000 }
+);
 
-// Parse JSON from response
-const output = JSON.parse(response.content[0].text);
+if (response.stop_reason === 'max_tokens') {
+  // truncated output is an error, never a partial assessment
+}
 ```
+
+Two details that are easy to get wrong:
+
+- **`split().join()`, not `.replace()`.** `String.prototype.replace` with a
+  string pattern substitutes only the *first* occurrence, and a `$` sequence
+  in the replacement is interpreted as a special pattern. Document text is
+  untrusted input and may contain `$&` or `$1`, so `.replace()` is both
+  incomplete and unsafe here.
+- **The document is wrapped exactly once**, inside the template. The API
+  route sanitizes the text and passes it through as-is
+  (`src/app/api/compliance/route.ts`); it does not add delimiters.
 
 ### Model string to use
 ```
-claude-haiku-3-5-20241022
+claude-haiku-4-5-20251001
 ```
 Always use this exact string. Do not use aliases.
+
+> **Known drift.** `src/lib/anthropic/CLAUDE.md` requires this string to be
+> defined once in `client.ts` and imported. It is not: `client.ts` exports
+> only `getAnthropicClient()`, and the literal is duplicated across all four
+> agent modules plus `MODEL_USED` in `src/app/api/compliance/route.ts`.
+> Five copies means five places to miss on the next model upgrade — which is
+> how the docs came to reference a model this project never used.
 
 ### Token budget per agent
 - Pillar agents (CS / OA / OM): max tokens 3000 — sufficient for full gap

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,8 @@ Prova is a well-architected Next.js 16 monolith deployed on Vercel. The frontend
 │              NEXT.JS API ROUTES (Vercel)             │
 │                                                      │
 │  /api/compliance  /api/submissions  /api/report      │
-│  /api/health                                         │
+│  /api/health      /api/benchmarks                    │
+│  /api/benchmarks/disclosure                          │
 └─────────────────────────────────────────────────────┘
           │                    │
           ▼                    ▼
@@ -27,7 +28,7 @@ Prova is a well-architected Next.js 16 monolith deployed on Vercel. The frontend
 │  ANTHROPIC API   │  │         SUPABASE              │
 │                  │  │                               │
 │  Claude Haiku    │  │  PostgreSQL + Auth + RLS      │
-│  3.5             │  │                               │
+│  4.5             │  │                               │
 └──────────────────┘  └──────────────────────────────┘
 ```
 
@@ -52,12 +53,13 @@ User submits document
 │     - DOCX → mammoth   → extracted text               │
 │     - File deleted from memory immediately             │
 │  5. Sanitize text (strip HTML, scripts)                │
-│  6. Wrap in XML delimiters                             │
+│     (<document> delimiters are added by each agent's    │
+│      prompt template, not here)                        │
 └───────────────────────────────────────────────────────┘
         │
         ▼
 ┌───────────────────────────────────────────────────────┐
-│  PARALLEL AGENT EXECUTION (Promise.all)                │
+│  PARALLEL AGENT EXECUTION (Promise.allSettled)         │
 │                                                        │
 │  ┌─────────────────┐  ┌─────────────────┐  ┌────────┐ │
 │  │ Conceptual      │  │ Outcomes        │  │Ongoing │ │
@@ -125,7 +127,7 @@ Return ComplianceResponse to client
 User visits /dashboard
         │
         ▼
-Next.js proxy.ts
+Next.js middleware.ts
         │
         ├── Has valid Supabase session? ──YES──► Render page
         │
@@ -168,6 +170,9 @@ users (Supabase Auth)
   │               gap_analysis    JSONB
   │               judge_confidence
   │               assessment_confidence_label
+  │               retry_count
+  │               model_type      ENUM
+  │               is_synthetic   BOOLEAN
   │               created_at
   │                   │
   │                   └── gaps
@@ -201,7 +206,7 @@ orchestrator.ts
       │
       ├── ATTEMPT (max 3 total: 1 initial + 2 retries)
       │
-      │   Promise.all([
+      │   Promise.allSettled([
       │     conceptualSoundness(document, context?)
       │     outcomesAnalysis(document, context?)
       │     ongoingMonitoring(document, context?)
@@ -232,7 +237,7 @@ orchestrator.ts
 User clicks "Download Report" on /submissions/[id]
         │
         ▼
-POST /api/report  { submissionId }
+POST /api/report  { submission_id }
         │
         ▼
 Fetch submission + gaps from Supabase (verify user_id match)
@@ -258,18 +263,25 @@ CLIENT
   │  HTTPS only (enforced by Vercel)
   │
   ▼
-NEXT.JS PROXY (proxy.ts)
-  │  - Supabase session verification
-  │  - Redirect unauthenticated requests
+NEXT.JS MIDDLEWARE (src/middleware.ts)
+  │  - CSRF: Origin header required and matched against
+  │    NEXT_PUBLIC_APP_URL on POST/PUT/DELETE/PATCH to /api/*
+  │  - Supabase session refresh + verification (getUser, not getSession)
+  │  - Unauthenticated: 401 JSON for /api/*, redirect for pages
   │
   ▼
 API ROUTES
-  │  - Server-side session re-verification (defense in depth)
+  │  - Server-side session re-verification (defense in depth —
+  │    middleware can be bypassed, RLS and this check cannot)
   │  - Rate limiting check (rateLimit.ts)
   │  - Input validation (Zod schemas)
-  │  - File type validation (sanitize.ts)
+  │  - File extension + MIME validation (validateFileType), then
+  │    magic-byte inspection of the buffer itself
+  │    (validateFileMagicBytes, sanitize.ts) — a .docx renamed to
+  │    .pdf is rejected on content, not on its declared type
+  │  - 10MB cap enforced server-side; buffer zeroed with
+  │    buffer.fill(0) in a finally block after text extraction
   │  - Text sanitization (sanitize.ts)
-  │  - XML delimiter wrapping (before Claude)
   │
   ▼
 ANTHROPIC API
@@ -301,7 +313,7 @@ Write to Supabase: evals table
   - judge_output (JSONB)
   - retry_count
   - total_latency_ms
-  - model_used (haiku-3-5)
+  - model_used (claude-haiku-4-5-20251001)
   - timestamp
         │
         ▼

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,6 +1,6 @@
 # Dashboard & Versioning
 
-Extracted from PRD Sections 3.7–3.8, 14.4. This is the focused reference for dashboard work.
+Focused reference for dashboard work — sections, versioning, and settings toggles.
 
 ---
 
@@ -15,8 +15,10 @@ All users see same base dashboard. Users can hide/show sections in Settings > Da
 - Most recent submission with timestamp
 
 ### Model Inventory Table
-- Columns: Model Name, Version, Submission Date, CS Score, OA Score, OM Score, Final Score, Status, Actions
-- Sorting: by any column
+- Sortable columns (`COLUMNS` in `ModelInventoryTable.tsx`): Model Name,
+  Version, Submission Date, CS, OA, OM, Final
+- Status is rendered as a badge in its own cell, derived from the final score
+  rather than stored — it is not a sortable column
 - Filtering: by status, date range, score range
 - Pagination: 10 rows per page
 
@@ -41,7 +43,9 @@ All users see same base dashboard. Users can hide/show sections in Settings > Da
 
 ## Settings Page Toggles
 
-Four dashboard section toggles stored in user preferences (Supabase `user_preferences` table or localStorage fallback):
+Four dashboard section toggles stored in the Supabase `user_preferences`
+table. There is no localStorage fallback — preferences are read server-side
+during dashboard render, so a signed-in session is always required:
 
 ```typescript
 {
@@ -51,3 +55,26 @@ Four dashboard section toggles stored in user preferences (Supabase `user_prefer
   show_recent_activity: boolean       // default: true
 }
 ```
+
+---
+
+## Benchmarks View
+
+A separate page at `/dashboard/benchmarks`
+(`src/components/dashboard/BenchmarksView.tsx`), linked from the main nav.
+Unlike the four sections above it has **no settings toggle** — it is always
+available.
+
+- Compares one of the user's own assessments against corpus medians for the
+  same `model_type` (CS / OA / OM / final)
+- Cross-user aggregates come exclusively from the `get_benchmark_stats` RPC,
+  never a direct table read — the `SECURITY DEFINER` function is the only
+  path by which another user's data influences what is displayed, and it
+  returns aggregates only
+- Top gap elements are returned as `element_code` + `element_name` +
+  frequency, never gap descriptions or recommendations
+- When the bucket holds fewer than `BENCHMARK_MIN_CORPUS_N` (5) submissions,
+  medians are suppressed and the UI renders an explicit
+  "Insufficient corpus (N=X)" state rather than a misleading comparison
+- The model picker lists the signed-in user's own submissions only, scoped by
+  RLS on the base select

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -35,6 +35,12 @@ CREATE TABLE public.models (
 ```
 
 ### 2.2 submissions
+
+> `model_type` and `is_synthetic` are added by
+> `supabase/migrations/20260501000000_model_type_benchmarks.sql`, which also
+> creates the `public.model_type` enum this column depends on. Apply that
+> migration after creating the tables below — see §2.6.
+
 ```sql
 CREATE TABLE public.submissions (
   id                          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -104,10 +110,47 @@ CREATE TABLE public.evals (
   judge_output        JSONB NOT NULL,
   retry_count         INTEGER NOT NULL DEFAULT 0,
   total_latency_ms    INTEGER,
-  model_used          TEXT NOT NULL DEFAULT 'claude-haiku-3-5-20241022',
+  model_used          TEXT NOT NULL DEFAULT 'claude-haiku-4-5-20251001',
   created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
+
+### 2.6 Model-type tagging and benchmark functions (migration)
+
+Everything in this section is applied by
+`supabase/migrations/20260501000000_model_type_benchmarks.sql`. Run it **after**
+creating the tables above — it uses `ALTER TABLE`, so the tables must exist.
+Do not hand-copy it; apply the migration file so the repo stays the source of
+truth.
+
+It creates:
+
+| Object | Purpose |
+|---|---|
+| `public.model_type` enum | 8 values, from `credit_risk_pd_lgd_ead` to `other`. Must stay in lockstep with `ModelTypeEnum` in `src/lib/validation/schemas.ts`. |
+| `submissions.model_type` | `NOT NULL DEFAULT 'other'` — groups benchmarks by comparable model class. |
+| `submissions.is_synthetic` | `NOT NULL DEFAULT FALSE` — keeps synthetic test documents from inflating real-corpus statistics. |
+| `idx_submissions_model_type_is_synthetic` | Composite index backing the benchmark filter + count path. |
+| `get_benchmark_stats(model_type, boolean)` | Per-bucket corpus aggregates. |
+| `get_corpus_disclosure()` | Global counts for the disclosure banner. |
+
+**Both functions are `SECURITY DEFINER`, and that is the privacy boundary.**
+They read across all users' submissions without RLS being relaxed on the base
+tables. The guarantees are enforced inside the function bodies:
+
+- No `user_id`, `submission_id`, `document_text`, or raw gap description /
+  recommendation is ever returned — only aggregates.
+- `top_gaps` returns `element_code` + `element_name` + frequency only.
+- Execution is locked down. Both functions carry
+  `REVOKE ALL ... FROM PUBLIC, anon` and `GRANT EXECUTE ... TO authenticated`.
+  Without the REVOKE, anyone holding the publishable key could call a
+  `SECURITY DEFINER` function that reads every user's rows. **If you recreate
+  these functions by hand, you must reapply the REVOKE — a `CREATE OR REPLACE`
+  that omits it silently opens cross-user aggregate access.**
+- Small-N suppression is a *caller-side* responsibility: the API layer hides
+  the medians when `corpus_n < 5` (`BENCHMARK_MIN_CORPUS_N`) to prevent
+  single-row inference. The function still returns the true `corpus_n` so the
+  UI can render an honest "Insufficient corpus (N=X)" state.
 
 ---
 
@@ -137,6 +180,25 @@ CREATE INDEX idx_user_preferences_user_id ON public.user_preferences(user_id);
 CREATE INDEX idx_evals_submission_id ON public.evals(submission_id);
 CREATE INDEX idx_evals_created_at ON public.evals(created_at DESC);
 ```
+
+### Rate limiting has no table of its own
+
+`checkRateLimit` (`src/lib/security/rateLimit.ts`) does not read a counter
+table. It issues a `head: true, count: 'exact'` query against `submissions`
+filtered by `user_id` and `created_at >= now() - 1 hour`, using the **service
+client**, so the count is not narrowed by RLS.
+
+`idx_submissions_user_id_created_at` is what makes that query cheap — it is
+the covering index for the rate-limit path, not only for dashboard listing.
+Dropping it would silently degrade every compliance submission.
+
+Two consequences worth knowing:
+
+- The limit is a rolling one-hour window, not a fixed quota that resets on the
+  hour.
+- Only *successful* submissions count, because a row only exists once the
+  assessment has been written. A run that fails mid-way is not charged
+  against the user's limit.
 
 ---
 
@@ -329,23 +391,25 @@ import { createBrowserClient } from '@supabase/ssr';
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!
   );
 }
 ```
 
 ### 7.2 Server client (`/src/lib/supabase/server.ts`)
 ```typescript
-import { createServerClient } from '@supabase/ssr';
+import { createServerClient as createSupabaseServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 
-// Use this in API routes and Server Components
-export async function createClient() {
+// Use this in API routes and Server Components.
+// Exported as createServerClient — the @supabase/ssr import is aliased to
+// avoid a name collision.
+export async function createServerClient() {
   const cookieStore = await cookies();
 
-  return createServerClient(
+  return createSupabaseServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
     {
       cookies: {
         getAll() { return cookieStore.getAll(); },
@@ -363,9 +427,9 @@ export async function createClient() {
 
 // Use this for operations that need to bypass RLS (server-side only)
 export function createServiceClient() {
-  return createServerClient(
+  return createSupabaseServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    process.env.SUPABASE_SECRET_KEY!,
     { cookies: { getAll: () => [], setAll: () => {} } }
   );
 }
@@ -381,7 +445,7 @@ export async function updateSession(request: NextRequest) {
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
     {
       cookies: {
         getAll() { return request.cookies.getAll(); },
@@ -422,15 +486,15 @@ export async function updateSession(request: NextRequest) {
 
 ```env
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-anon-key
+SUPABASE_SECRET_KEY=your-service-role-key
 ```
 
 The service role key is used ONLY in:
 - `createServiceClient()` in `/src/lib/supabase/server.ts`
 - Writing to the `evals` table (bypasses RLS)
 
-Never reference `SUPABASE_SERVICE_ROLE_KEY` anywhere else.
+Never reference `SUPABASE_SECRET_KEY` anywhere else.
 
 ---
 

--- a/docs/ERROR_STATES.md
+++ b/docs/ERROR_STATES.md
@@ -1,7 +1,7 @@
 # Prova — Error States
 **Version:** 1.0 | **Date:** March 19, 2026
 
-<!-- SUMMARY: 16 error codes. Quick reference table (code, HTTP status, trigger): §1.
+<!-- SUMMARY: 15 error codes. Quick reference table (code, HTTP status, trigger): §1.
 Full detail per error (trigger, message, UI behavior, recovery): §2.
 Toast specs: §3 | API response format: §4 | errorResponse() pattern: §5 -->
 
@@ -25,7 +25,6 @@ Implement all error states exactly as defined here — do not invent error messa
 | `DOCUMENT_TOO_LONG` | 400 | Text exceeds 50,000 characters |
 | `AI_UNAVAILABLE` | 503 | Anthropic API call failed |
 | `AI_SCHEMA_INVALID` | 500 | Agent returned malformed JSON after max retries |
-| `ASSESSMENT_LOW_CONFIDENCE` | 200 | Check succeeded but judge confidence < 0.6 after retries |
 | `SUBMISSION_NOT_FOUND` | 404 | Submission ID does not exist or belongs to another user |
 | `REPORT_GENERATION_FAILED` | 500 | React-PDF failed to generate report |
 | `DATABASE_ERROR` | 500 | Supabase write/read failed |
@@ -45,6 +44,12 @@ Implement all error states exactly as defined here — do not invent error messa
 ---
 
 ### AUTH_INVALID
+> **Defined but unused.** `AUTH_INVALID` exists in `ErrorCode` and `ERRORS`,
+> but no route returns it — every API route returns `AUTH_REQUIRED` for a
+> failed server-side session check, and both codes carry the same 401 status
+> and the same message. Kept for the case where expired and absent sessions
+> need to be distinguished; today they are not.
+
 **Trigger:** Session token exists but is expired or invalid when verified server-side in an API route.
 **HTTP:** 401
 **API response:**
@@ -69,7 +74,7 @@ Implement all error states exactly as defined here — do not invent error messa
 {
   "error": "RATE_LIMIT_EXCEEDED",
   "error_code": "RATE_LIMIT_EXCEEDED",
-  "message": "You have reached the assessment limit. Try again in 23 minutes.",
+  "message": "Assessment limit reached. Try again in 23 minutes.",
   "retry_after_seconds": 1380
 }
 ```
@@ -226,45 +231,52 @@ All API errors return this structure (defined in `ErrorResponseSchema` in `/docs
 
 In every API route, use this error handler pattern:
 
+`errorResponse()` is defined once in `src/lib/errors/messages.ts` and imported
+by every route. Never redefine it locally.
+
 ```typescript
-// /src/app/api/compliance/route.ts
+export function errorResponse(
+  code: ErrorCode,
+  options?: { message?: string; extras?: Record<string, unknown> }
+)
+```
 
-import { NextResponse } from 'next/server';
+The HTTP status is **not** a parameter — it is looked up from the `ERRORS`
+table by `code`, so a given code can never return two different statuses from
+two different routes. `message` defaults to the canonical text and is
+overridden only where the message is dynamic (rate limits, Zod issues).
 
-function errorResponse(
-  error_code: string,
-  message: string,
-  status: number,
-  extras?: object
-) {
-  return NextResponse.json(
-    { error: error_code, error_code, message, ...extras },
-    { status }
-  );
-}
+```typescript
+// src/app/api/compliance/route.ts
+import { errorResponse } from '@/lib/errors/messages';
 
 export async function POST(request: Request) {
-  // Auth check
-  const supabase = await createClient();
+  const supabase = await createServerClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    return errorResponse('AUTH_INVALID', 'Your session has expired. Please log in again.', 401);
+    return errorResponse('AUTH_REQUIRED');
   }
 
-  // Rate limit check
-  const isRateLimited = await checkRateLimit(user.id);
-  if (isRateLimited.exceeded) {
-    return errorResponse(
-      'RATE_LIMIT_EXCEEDED',
-      `Assessment limit reached. Try again in ${Math.ceil(isRateLimited.retryAfter / 60)} minutes.`,
-      429,
-      { retry_after_seconds: isRateLimited.retryAfter }
+  const rateLimit = await checkRateLimit(user.id);
+  if (!rateLimit.allowed) {
+    const resetAt = rateLimit.resetAt!;
+    const retryAfterSeconds = Math.max(
+      0,
+      Math.ceil((resetAt.getTime() - Date.now()) / 1000)
     );
+    const retryAfterMinutes = Math.ceil(retryAfterSeconds / 60);
+    return errorResponse('RATE_LIMIT_EXCEEDED', {
+      message: `Assessment limit reached. Try again in ${retryAfterMinutes} minutes.`,
+      extras: { retry_after_seconds: retryAfterSeconds },
+    });
   }
 
   // ... rest of handler
 }
 ```
+
+`checkRateLimit` returns `{ allowed: boolean; resetAt?: Date }` — a reset
+timestamp, not a duration. The route derives the countdown from it.
 
 ---
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -13,10 +13,25 @@ npm install zod
 
 ---
 
-## Complete schemas.ts File
+## Reference: schemas.ts
+
+> **`src/lib/validation/schemas.ts` is the source of truth, not this file.**
+> What follows is an annotated reference covering the schemas you will touch
+> most often. It is not a complete transcription — the module also exports the
+> element-code enums, `PillarScoresSchema`, `ScoringInputSchema`,
+> `ModelRowSchema`, and the benchmark schemas documented in §Benchmarks below.
+> When the two disagree, the code wins; fix the doc.
 
 ```typescript
 import { z } from 'zod';
+
+// ─── File upload constants ───────────────────────────────────────────────
+export const ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+] as const;
+export const ALLOWED_EXTENSIONS = ['.pdf', '.docx'] as const;
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ENUMS
@@ -37,6 +52,24 @@ export const StatusEnum = z.enum([
 ]);
 
 export const ConfidenceLabelEnum = z.enum(['High', 'Medium', 'Low']);
+
+// Model type — must stay in lockstep with the public.model_type SQL enum
+// (see supabase/migrations/20260501000000_model_type_benchmarks.sql).
+// Adding a value here without the matching ALTER TYPE will fail at insert.
+export const ModelTypeEnum = z.enum([
+  'credit_risk_pd_lgd_ead',
+  'allowance_cecl_ifrs9',
+  'market_risk_var',
+  'alm_irrbb',
+  'stress_testing_ccar',
+  'aml_fraud',
+  'credit_decisioning',
+  'other'
+]);
+
+export type ModelType = z.infer<typeof ModelTypeEnum>;
+
+// MODEL_TYPE_LABELS maps each enum value to its display string — see code.
 
 // CS element codes
 export const CSElementCodeEnum = z.enum([
@@ -182,6 +215,12 @@ export const ComplianceRequestSchema = z.object({
     .min(1, 'Model name is required')
     .max(200, 'Model name must be under 200 characters')
     .regex(/^[a-zA-Z0-9 \-_().]+$/, 'Model name contains invalid characters'),
+  model_type: ModelTypeEnum.default('other'),
+  // is_synthetic must be settable at submission time so the test suite can tag
+  // synthetic-corpus runs without polluting real-corpus benchmark stats. The
+  // route handler is the trust boundary — clients may pass true, but only
+  // authenticated users can submit at all and synthetic-tagging is benign.
+  is_synthetic: z.boolean().default(false),
   document_text: z.string()
     .min(100, 'Document must be at least 100 characters')
     .max(50000, 'Document must be under 50,000 characters')
@@ -225,6 +264,8 @@ export type ComplianceResponse = z.infer<typeof ComplianceResponseSchema>;
 export const SubmissionListItemSchema = z.object({
   id: z.string().uuid(),
   model_name: z.string(),
+  model_type: ModelTypeEnum,
+  is_synthetic: z.boolean(),
   version_number: z.number().int().min(1),
   conceptual_score: z.number().min(0).max(100),
   outcomes_score: z.number().min(0).max(100),
@@ -238,9 +279,17 @@ export const SubmissionListItemSchema = z.object({
 export type SubmissionListItem = z.infer<typeof SubmissionListItemSchema>;
 
 // GET /api/submissions/[id] — full submission response
+// Detail view needs each gap's row id so the UI can key and link individual
+// gaps — the list view does not, so only this schema carries it.
+export const GapWithIdSchema = GapSchema.extend({
+  id: z.string().uuid()
+});
+
+export type GapWithId = z.infer<typeof GapWithIdSchema>;
+
 export const SubmissionDetailSchema = SubmissionListItemSchema.extend({
   document_text: z.string().min(100).max(50000),
-  gap_analysis: z.array(GapSchema),
+  gap_analysis: z.array(GapWithIdSchema),
   judge_confidence: z.number().min(0).max(1)
 });
 
@@ -265,12 +314,15 @@ export const SubmissionRowSchema = z.object({
   model_id: z.string().uuid(),
   user_id: z.string().uuid(),
   version_number: z.number().int().min(1),
+  model_type: ModelTypeEnum,
+  is_synthetic: z.boolean(),
   document_text: z.string().min(100).max(50000),
   conceptual_score: z.number(),
   outcomes_score: z.number(),
   monitoring_score: z.number(),
   final_score: z.number(),
   gap_analysis: z.array(GapSchema).nullable(),
+  retry_count: z.number().int().min(0).max(2),
   judge_confidence: z.number(),
   assessment_confidence_label: ConfidenceLabelEnum,
   created_at: z.string().datetime()
@@ -393,6 +445,62 @@ export async function POST(request: Request) {
   // proceed...
 }
 ```
+
+---
+
+## Benchmarks
+
+Backing `GET /api/benchmarks` and `GET /api/benchmarks/disclosure`.
+
+```typescript
+// Below this corpus size, medians are suppressed rather than shown.
+// A median over 1–4 rows can equal another user's exact score, so publishing
+// it would leak individual data through an aggregate endpoint.
+export const BENCHMARK_MIN_CORPUS_N = 5;
+
+export const TopGapEntrySchema = z.object({
+  element_code: ElementCodeEnum,
+  element_name: z.string(),
+  frequency: z.number().int().min(0)
+});
+
+export const BenchmarkStatsSchema = z.object({
+  model_type: ModelTypeEnum,
+  include_synthetic: z.boolean(),
+  corpus_n: z.number().int().min(0),
+  synthetic_n: z.number().int().min(0),
+  real_n: z.number().int().min(0),
+  // Medians are nullable: suppressed when corpus_n < BENCHMARK_MIN_CORPUS_N
+  // (server-side enforcement on top of any client-side guard).
+  cs_median: z.number().min(0).max(100).nullable(),
+  oa_median: z.number().min(0).max(100).nullable(),
+  om_median: z.number().min(0).max(100).nullable(),
+  final_median: z.number().min(0).max(100).nullable(),
+  top_gaps: z.array(TopGapEntrySchema)
+});
+
+export const CorpusDisclosureSchema = z.object({
+  total_n: z.number().int().min(0),
+  synthetic_n: z.number().int().min(0),
+  real_n: z.number().int().min(0)
+});
+
+export const BenchmarkQuerySchema = z.object({
+  model_type: ModelTypeEnum,
+  include_synthetic: z.coerce.boolean().default(true)
+});
+```
+
+Two things these schemas encode deliberately:
+
+- **The medians are `.nullable()`, not optional.** Suppression is a value the
+  API returns, not a field it omits, so a client cannot mistake "withheld for
+  privacy" for "not sent". `corpus_n` is always returned truthfully so the UI
+  can render "Insufficient corpus (N=X)".
+- **`top_gaps` carries `element_code`, `element_name` and a frequency — and
+  nothing else.** No description, no recommendation, no submission or user id.
+  The schema is the second line of defence behind the `SECURITY DEFINER`
+  function; both are written so per-row content cannot leave the database.
 
 ---
 

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -1,6 +1,6 @@
 # Scoring System
 
-Extracted from PRD Sections 3.5–3.6, 14.3. This is the focused reference for scoring work.
+Focused reference for scoring work — formula, weights, deductions, and status thresholds.
 
 ---
 

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -1,6 +1,6 @@
 # UI/UX Design
 
-Extracted from PRD Section 8. This is the focused reference for component work.
+Focused reference for component work — colours, typography, and UI principles.
 
 ---
 
@@ -22,6 +22,18 @@ Banking-appropriate refined minimalism. Data is the hero. Numbers and scores dom
 ```
 
 All colors defined as CSS variables in `globals.css` — **never hardcode hex values**.
+
+The ten above are the core tokens, exposed as Tailwind utilities via
+`tailwind.config.ts` (`bg-primary`, `text-critical`, `border`, …).
+`globals.css` defines 32 `--color-*` tokens in total: the ten core ones plus
+22 derived tints, borders and rules layered on top — `--color-accent-light`,
+`--color-compliant-bg`, `--color-compliant-border`,
+`--color-text-secondary-dim`, `--color-white-divider` and similar.
+
+Read `globals.css` before introducing a new colour; the derived token you
+need usually already exists. Note the set is not symmetrical — `compliant`
+has `-bg` and `-border` variants while `critical` and `warning` do not, so
+check rather than assume a variant exists.
 
 ## Typography
 - Display/headings: **Playfair Display** — authoritative, editorial
@@ -47,6 +59,7 @@ All colors defined as CSS variables in `globals.css` — **never hardcode hex va
 /signup              Signup
 /reset-password      Password reset
 /dashboard           Main dashboard (authenticated)
+/dashboard/benchmarks  Corpus benchmark comparison by model type
 /check               New compliance check
 /submissions         All submissions list
 /submissions/[id]    Single submission results

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -85,7 +85,8 @@ export const MODEL_TYPE_LABELS: Record<ModelType, string> = {
   other: "Other",
 };
 
-// SR 11-7 element codes — exactly the codes defined in PRD Section 14.5
+// SR 11-7 element codes — must match the reference tables in
+// docs/AGENT_ARCHITECTURE.md and the agent prompts in docs/AGENT_PROMPTS.md
 export const CSElementCodeEnum = z.enum([
   "CS-01",
   "CS-02",


### PR DESCRIPTION
## Context

**PR #82 was merged, but its content never reached `main`.** This re-targets it.

#82's base was `fix/disputes-schema-remnants` (PR #81's branch), because #82 was stacked on #81 to avoid a conflict in `AGENT_PROMPTS.md`. I said GitHub would retarget it to `main` automatically once #81 merged. **That was wrong** — GitHub only auto-retargets a stacked PR when the base branch is *deleted* on merge. The branch wasn't deleted, so:

| Event | Time | Target |
|---|---|---|
| #81 merged | 05:29:37 | `main` ✅ |
| #82 merged | 06:50:35 | `fix/disputes-schema-remnants` ❌ |

#82 landed on a branch that had already been merged an hour earlier. Verified:

```
$ git merge-base --is-ancestor 26e4b58 origin/main
NO

$ git show origin/main:docs/AGENT_PROMPTS.md | grep -c "claude-haiku-3-5"
2          # stale model string still on main

$ git show origin/main:docs/ERROR_STATES.md | grep -c "ASSESSMENT_LOW_CONFIDENCE"
1          # phantom error code still on main
```

## Logic

The original docs commit `26e4b58` **cherry-picked** onto current `main` as `8299bf1`. Content is byte-identical; only the parent changed.

**Merging `fix/disputes-schema-remnants` into `main` was not an option.** That branch predates #80, #83 and #84, so the merge would have re-added `CustomCursor.tsx`, `Input.tsx`, `Table.tsx`, `Footer.tsx` and both `MCP_SETUP*.md` files, and reverted the Sentry, sanitizer and version-numbering fixes — a 33-file bidirectional diff. Cherry-picking the single docs commit avoids all of that.

## Edge Cases

- **Clean cherry-pick, no conflicts.** The docs commit touches only `docs/`, `README.md`, and one comment in `schemas.ts` — none of which #83 or #84 modified.
- **Re-verified against current `main`, not the tree it was written for.** No occurrences remain in `docs/` or `README.md` of: `haiku-3-5`, `proxy.ts`, `Promise.all(`, `ASSESSMENT_LOW_CONFIDENCE`, `SUPABASE_ANON_KEY`, `SERVICE_ROLE_KEY`, `PRD.md`.
- `npm test` 314 passing, `tsc --noEmit` clean.
- **Cleanup:** `fix/disputes-schema-remnants` and `docs/accuracy-pass` can both be deleted after this merges. Deleting base branches on merge would have prevented this entirely.

## Alternatives Considered

- **Merge `fix/disputes-schema-remnants` → `main`** — rejected; reverts three merged PRs.
- **Revert and redo the docs work** — unnecessary; the commit applies cleanly.

## Review Focus

Content is unchanged from #82, which you already reviewed. The only thing worth confirming is that this now sits on top of #80–#84 rather than underneath them.

---

## AI Disclosure
| Field | Details |
|-------|---------|
| AI-generated | ~95% |
| Tool used | Claude Code (claude-opus-5) |
| Human review | Loss detected by checking merged content against `origin/main` rather than trusting the PR's MERGED status. |

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm test` passes (314 tests)
- [x] Documentation-only, plus one comment change in `schemas.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
